### PR TITLE
fix-scroll to top of results after handle pagination event

### DIFF
--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -127,6 +127,8 @@ const createHomepageUtils = (_$w, filterProfiles) => {
 
     paginateSearchResults(searchResults, pagination);
     await updateUrlParams(filter, pagination);
+
+    _$w('#resultsStateBox').scrollTo();
   }
 
   async function onChangeMultiCheckbox({


### PR DESCRIPTION
Solves this bug:
https://wix.monday.com/boards/9601070284/pulses/18377707837