### PR TITLE
accept hyphen on regex

### DIFF
--- a/backend/daily-pull/utils.js
+++ b/backend/daily-pull/utils.js
@@ -84,7 +84,7 @@ const validateCoreMemberData = inputMemberData => {
   return true;
 };
 
-const containsNonEnglish = str => /[^a-zA-Z0-9]/.test(str); // if it contains any non-english characters, test1 is allowed, but any others are not
+const containsNonEnglish = str => /[^a-zA-Z0-9-]/.test(str); // if it contains any non-english characters or invalid URL chars, test1 is allowed, hyphens are allowed
 
 /**
  * Creates a full name from first and last name components


### PR DESCRIPTION
## 🐛 **The Problem:**

The URL `20-w-main-street-georgetown-ma` contains **hyphens (`-`)**, which are:
- ✅ **Valid** in URLs (routers accept them)
- ❌ **Rejected** by your regex because `-` is not in `[a-zA-Z0-9]`

So `containsNonEnglish("20-w-main-street-georgetown-ma")` returns `true`, incorrectly flagging it as "non-English".

Monday ticket: https://wix.monday.com/boards/9601070284/pulses/10634475484

## ✅ **The Fix:**

You need to add hyphens to the allowed character set:

```javascript
const containsNonEnglish = str => /[^a-zA-Z0-9-].test(str)
```

This will now allow:
- Letters: `a-z`, `A-Z`
- Numbers: `0-9`
- Hyphens: `-`

And will correctly flag URLs with actual non-English characters like `café` or `日本` as invalid.