### PR TITLE
Fix: update incrementUrlCounter

### DIFF
--- a/backend/daily-pull/utils.js
+++ b/backend/daily-pull/utils.js
@@ -35,7 +35,17 @@ const extractBaseUrl = url => {
   return url;
 };
 const incrementUrlCounter = (existingUrl, baseUrl) => {
-  if (existingUrl && existingUrl === baseUrl) {
+  if (!existingUrl || !baseUrl) {
+    return baseUrl;
+  }
+  // Normalize for comparison (case-insensitive)
+  const normalizedExisting = existingUrl.toLowerCase();
+  const normalizedBase = baseUrl.toLowerCase();
+
+  if (
+    normalizedExisting === normalizedBase ||
+    normalizedExisting.startsWith(`${normalizedBase}-`)
+  ) {
     console.log(
       `Found member with same url ${existingUrl} for baseUrl ${baseUrl}, increasing counter by 1`
     );
@@ -44,6 +54,9 @@ const incrementUrlCounter = (existingUrl, baseUrl) => {
     const lastCounter = isNumeric ? parseInt(lastSegment, 10) : 0;
     return `${baseUrl}-${lastCounter + 1}`;
   }
+
+  // No conflict, return baseUrl with counter 1 to be safe
+  return `${baseUrl}-1`;
 };
 /**
  * Validates core member data requirements


### PR DESCRIPTION
Problematic item example:
<img width="1085" height="143" alt="Attached_image" src="https://github.com/user-attachments/assets/51383b82-5382-4245-ae88-7179ea0b0719" />
<img width="1191" height="281" alt="Attached_image2" src="https://github.com/user-attachments/assets/3b11684c-014f-40ee-91ac-917f881d759a" />


**The bug**: 
1. `getMemberBySlug` with `normalizeSlugForComparison: true` finds `elenachavez` (lowercase in DB)
2. `incrementUrlCounter('elenachavez', 'ElenaChavez')` is called
3. `'elenachavez' !== 'ElenaChavez'` (strict comparison), so it returns `undefined`
4. `member.url = undefined` **overwrites the valid URL!**

Here's the fix:

The issue was:

1. `ensureUniqueUrl` correctly generated `ElenaChavez-1`
2. Then `ensureUniqueUrlsInBatch` ran to handle batch deduplication
3. It found `elenachavez` in DB (case-insensitive search)
4. Called `incrementUrlCounter('elenachavez', 'ElenaChavez')`
5. **Strict equality `===` failed** because of case difference
6. Function returned `undefined`
7. `member.url = undefined` **overwrote the valid URL**

**The fix**: 

- Now does case-insensitive comparison
- Also handles the case where existing URL has a counter (e.g., `elenachavez-1`)
- Always returns a valid URL, never `undefined`