### PR TITLE
[Fix] Show "Directions" button only when address has valid coordinates

### DIFF
--- a/pages/Home.js
+++ b/pages/Home.js
@@ -216,12 +216,19 @@ const homePageOnReady = async ({
         $item('#milesAwayText').text = '';
       }
 
-      // 7) "Show maps" button enabled only if there's at least one visible address
+      // 7) "Show maps" button enabled only if there's a full address with valid coordinates
       const visible = checkAddressIsVisible(addresses);
-      if (visible.length && visible[0].addressStatus === ADDRESS_STATUS_TYPES.FULL_ADDRESS) {
+      const fullAddressWithValidCoords = visible.find(
+        addr =>
+          addr.addressStatus === ADDRESS_STATUS_TYPES.FULL_ADDRESS &&
+          addr.latitude &&
+          addr.longitude
+      );
+
+      if (fullAddressWithValidCoords) {
         $item('#showMaps').enable();
         $item('#showMaps').show();
-        const { latitude, longitude } = visible[0];
+        const { latitude, longitude } = fullAddressWithValidCoords;
         $item('#showMaps').link = `https://maps.google.com/?q=${latitude},${longitude}`;
         $item('#showMaps').target = '_blank';
       } else {


### PR DESCRIPTION
### Problem

The "Directions" button on member profile cards was appearing even when the address had invalid coordinates (0,0). This caused users to be directed to an incorrect location (Gulf of Guinea, off the coast of Africa) when clicking the link.

**Root cause:** The existing logic checked if `addressStatus === FULL_ADDRESS` before showing the button, but it used the **first visible address blindly** without validating that the coordinates were actually valid.

### Example

For a member with two addresses:
| Address | Status | Coordinates |
|---------|--------|-------------|
| Saint Paul, MN (PO Box) | `full_address` | `0, 0` ❌ (geocoding failed) |
| Austin, TX | `state_city_zip` | `30.33, -97.70` ✅ |

The button would show because Saint Paul was first in the array with `full_address` status, but clicking it would navigate to `https://maps.google.com/?q=0,0` (invalid location).

### Solution

Updated the button visibility logic to find an address that has **both**:
1. `addressStatus === FULL_ADDRESS`
2. Valid latitude AND longitude (non-zero/truthy values)

### Changes

| Before | After |
|--------|-------|
| Used first visible address blindly | Finds first address with `FULL_ADDRESS` **AND** valid lat/lng |
| Would show button for 0,0 coordinates | Button hidden if coordinates are falsy (0, null, undefined) |