### PR TITLE
[fix] Users with empty addressDisplayOption couldn't set primary

### DIFF
--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -1680,7 +1680,13 @@ async function personalDetailsOnReady({
       option.isMain = false;
     });
 
-    const selectedOption = itemMemberObj.addressDisplayOption.find(opt => opt.key === selectedId);
+    let selectedOption = itemMemberObj.addressDisplayOption.find(opt => opt.key === selectedId);
+
+    // If the option doesn't exist, create it
+    if (!selectedOption) {
+      selectedOption = { key: selectedId, isMain: false };
+      itemMemberObj.addressDisplayOption.push(selectedOption);
+    }
 
     selectedOption.isMain = true;
   }


### PR DESCRIPTION
The updateMainAddressSelection function assumes the addressDisplayOption array already has entries matching each address. But for users with empty addressDisplayOption: [], the function crashes.