### PR TITLE
Fix-daily-pull

### DIFF
--- a/backend/daily-pull/sync-to-cms-methods.js
+++ b/backend/daily-pull/sync-to-cms-methods.js
@@ -9,9 +9,10 @@ const { bulkProcessAndSaveMemberData } = require('./bulk-process-methods');
 const { SITES_WITH_INTERESTS_TO_MIGRATE } = require('./consts');
 const { isUpdatedMember, isSiteAssociatedMember } = require('./utils');
 
-async function syncMembersDataPerAction(action) {
+async function syncMembersDataPerAction(taskData) {
+  const { action, backupDate } = taskData;
   try {
-    const firstPageResponse = await fetchPACMembers(1, action);
+    const firstPageResponse = await fetchPACMembers({ page: 1, action, backupDate });
 
     if (
       !firstPageResponse ||
@@ -48,6 +49,7 @@ async function syncMembersDataPerAction(action) {
       data: {
         pageNumber,
         action,
+        ...(backupDate ? { backupDate } : {}),
       },
       type: 'scheduled',
     }));
@@ -74,11 +76,11 @@ async function syncMembersDataPerAction(action) {
  * @returns {Promise<Object>} - Page synchronization result
  */
 async function synchronizeSinglePage(taskObject) {
-  const { pageNumber, action } = taskObject.data;
+  const { pageNumber, action, backupDate } = taskObject.data;
   try {
     const [siteAssociation, memberDataResponse] = await Promise.all([
       getSiteConfigs(CONFIG_KEYS.SITE_ASSOCIATION),
-      fetchPACMembers(pageNumber, action),
+      fetchPACMembers({ page: pageNumber, action, backupDate }),
     ]);
     const addInterests = SITES_WITH_INTERESTS_TO_MIGRATE.includes(siteAssociation);
     if (

--- a/backend/jobs.js
+++ b/backend/jobs.js
@@ -13,12 +13,17 @@ async function runScheduledTasks() {
   }
 }
 
-async function scheduleDailyPullTask() {
+/**
+ * Schedule a daily pull task for the given backup date
+ * @param {string} backupDate - Optional. The date of the backup to pull in format YYYY-MM-DD
+ * @returns {Promise<void>}
+ */
+async function scheduleDailyPullTask(backupDate = null) {
   try {
     console.log('scheduleDailyPullTask started!');
     return await taskManager().schedule({
       name: TASKS_NAMES.ScheduleDailyMembersDataSync,
-      data: {},
+      data: backupDate ? { backupDate } : {}, // keeping it like this so it would be easier to understand which task was backed up which is not while looking into CMS.
       type: 'scheduled',
     });
   } catch (error) {

--- a/backend/pac-api-methods.js
+++ b/backend/pac-api-methods.js
@@ -1,4 +1,4 @@
-const { PAC_API_URL } = require('./consts');
+const { PAC_API_URL, BACKUP_API_URL } = require('./consts');
 const { getSecret } = require('./utils');
 
 const getHeaders = async () => {
@@ -8,8 +8,22 @@ const getHeaders = async () => {
   };
   return headers;
 };
-const fetchPACMembers = async (pageNum, actionFilter) => {
-  const url = `${PAC_API_URL}/Members?page=${pageNum}&actionFilter=${actionFilter}`;
+/**
+ *
+ * @param {*} params
+ * @param {number} params.page - The page number to fetch
+ * @param {string} params.action - The action to fetch
+ * @param {string} [params.backupDate] - Optional. The backup date to fetch in format YYYY-MM-DD, use only to fetch from backup endpoint not from PAC endpoint.
+ * @returns {Promise<Object>} - The response from the API
+ */
+const fetchPACMembers = async ({ page, action, backupDate }) => {
+  const baseUrl = backupDate ? BACKUP_API_URL : PAC_API_URL;
+  const queryParams = { page, actionFilter: action };
+  if (backupDate) {
+    queryParams.date = backupDate;
+  }
+  const url = `${baseUrl}/Members?${new URLSearchParams(queryParams).toString()}`;
+  console.log(`Fetching PAC members from:  ${url}`);
   const headers = await getHeaders();
   const fetchOptions = {
     method: 'get',
@@ -18,14 +32,14 @@ const fetchPACMembers = async (pageNum, actionFilter) => {
   const response = await fetch(url, fetchOptions);
   const responseType = response.headers.get('content-type');
   if (!responseType.includes('application/json')) {
-    const errorMessage = `[fetchPACMembers] got invalid responseType: ${responseType} for page ${pageNum} and actionFilter ${actionFilter}`;
+    const errorMessage = `[fetchPACMembers] got invalid responseType: ${responseType} for page ${page} and actionFilter ${action}`;
     console.error(errorMessage);
     throw new Error(errorMessage);
   }
   if (response.ok) {
     return response.json();
   } else {
-    const errorMessage = `[fetchPACMembers] failed with status ${response.status} for page ${pageNum} and actionFilter ${actionFilter}`;
+    const errorMessage = `[fetchPACMembers] failed with status ${response.status} for page ${page} and actionFilter ${action}`;
     console.error(errorMessage);
     throw new Error(errorMessage);
   }

--- a/backend/tasks/tasks-configs.js
+++ b/backend/tasks/tasks-configs.js
@@ -43,7 +43,7 @@ const TASKS = {
   },
   [TASKS_NAMES.ScheduleMembersDataPerAction]: {
     name: TASKS_NAMES.ScheduleMembersDataPerAction,
-    getIdentifier: task => task.data.action,
+    getIdentifier: task => task.data,
     process: syncMembersDataPerAction,
     shouldSkipCheck: () => false,
     estimatedDurationSec: 6,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abmp-npm",
-  "version": "2.0.15",
+  "version": "2.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "abmp-npm",
-      "version": "2.0.15",
+      "version": "2.0.17",
       "license": "ISC",
       "dependencies": {
         "@wix/automations": "^1.0.261",
@@ -30,7 +30,7 @@
         "lodash": "^4.17.21",
         "ngeohash": "^0.6.3",
         "phone": "^3.1.67",
-        "psdev-task-manager": "1.1.7",
+        "psdev-task-manager": "1.1.9",
         "psdev-utils": "1.1.1"
       },
       "devDependencies": {
@@ -6762,9 +6762,9 @@
       "license": "MIT"
     },
     "node_modules/psdev-task-manager": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/psdev-task-manager/-/psdev-task-manager-1.1.7.tgz",
-      "integrity": "sha512-M1GYa/IHkppH0wjIZGRpuifjDrRF1eJ1vuKjdQ1ChMhpWxI+1usS6aRAfmkOFwqIkoNCm1JVObwncLEQH4DJFg==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/psdev-task-manager/-/psdev-task-manager-1.1.9.tgz",
+      "integrity": "sha512-faigISow4OZIrJBaMjob5WYsEzMZtj4/uPu0NKutnUuoRCSPExd3xr5QoUu05i9iZiwlMLHBUWHT5DkjmLgmtA==",
       "license": "ISC",
       "dependencies": {
         "@wix/data": "^1.0.273",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "csv-parser": "^3.0.0",
     "ngeohash": "^0.6.3",
     "phone": "^3.1.67",
-    "psdev-task-manager": "1.1.7",
+    "psdev-task-manager": "1.1.9",
     "psdev-utils": "1.1.1"
   }
 }


### PR DESCRIPTION
Monday: 
https://wix.monday.com/boards/9601070284/pulses/10968184005 

## PR: Add Backup Date Support for Daily Pull

### Summary
Added the ability to sync member data from a backup date instead of the live PAC API. This enables replaying historical data syncs.

### Changes

**`pac-api-methods.js`**
- Refactored `fetchPACMembers` to accept an object parameter: `{ page, action, backupDate }`
- When `backupDate` is provided, fetches from `BACKUP_API_URL` instead of `PAC_API_URL`
- Added JSDoc documentation
- Added request URL logging for debugging

**`sync-to-cms-methods.js`**
- Updated `syncMembersDataPerAction` to accept `taskData` object with `action` and `backupDate`
- Passes `backupDate` through child task scheduling
- Updated `synchronizeSinglePage` to forward `backupDate` when fetching members

**`jobs.js`**
- Added optional `backupDate` parameter to `scheduleDailyPullTask()`
- Added JSDoc documentation

**`tasks-configs.js`**
- Changed task identifier from `task.data.action` to `task.data` to include backup date in task identity

**Dependencies**
- Bumped `psdev-task-manager` from `1.1.7` → `1.1.9`: to get all scheduled tasks not only 1k items.
- Version bump: `2.0.15` → `2.0.17`

### Usage

// Normal daily pull (live data)
await scheduleDailyPullTask();

// Pull from a specific backup date
await scheduleDailyPullTask('2026-01-10');

## Notes
Backward compatible: existing calls without backupDate work as before
Backup date flows through entire task chain for traceability
