### PR TITLE
[Feature] Hide "miles away" label when nearby toggle is off

### DIFF
--- a/pages/Home.js
+++ b/pages/Home.js
@@ -211,9 +211,16 @@ const homePageOnReady = async ({
       // 5) Location text
       const mainAddress = getMainAddress(itemData.addressDisplayOption, addresses);
       $item('#location').text = mainAddress || '';
+
+      // 6) Miles away
+      const isNearbyEnabled = _$w('#nearBy').checked;
       const miles = itemData.distance ?? 0;
-      $item('#differenceInMiles').text = miles ? miles.toFixed(1) : '';
-      if (!miles) {
+
+      if (isNearbyEnabled && miles) {
+        $item('#differenceInMiles').text = miles.toFixed(1);
+        $item('#milesAwayText').text = 'miles away';
+      } else {
+        $item('#differenceInMiles').text = '';
         $item('#milesAwayText').text = '';
       }
 


### PR DESCRIPTION
## Summary

Updated the homepage to hide the "X miles away" label completely when the nearby toggle is disabled.

## Problem

Previously, the "miles away" label visibility was only based on whether a distance value existed. This meant the label could still appear when users were not searching by location, which was confusing for users that looks for zip code away from their homes. Also, this is client request 😅

## Testing

- Preview parameter: ?siteRevision=2&branchId=bb17a36b-ca25-44aa-911c-bdad94158be1&zip=80401&nearby=false&page=1