### PR TITLE
[Fix] Fix next button staying disabled when search results have multiple pages

### DIFF
--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -120,9 +120,11 @@ const createHomepageUtils = (_$w, filterProfiles) => {
   });
   async function handlePagination({ delta, pagination, searchResults, filter }) {
     const newPage = pagination.currentPage + delta;
-    if (newPage < 0 || newPage > 9) return;
+    const maxPage = pagination.totalPages ? pagination.totalPages - 1 : 0;
+    if (newPage < 0 || newPage > maxPage) return;
+
     newPage === 0 ? _$w('#previousPage').disable() : _$w('#previousPage').enable();
-    newPage === 9 ? _$w('#nextPage').disable() : _$w('#nextPage').enable();
+    newPage === maxPage ? _$w('#nextPage').disable() : _$w('#nextPage').enable();
     pagination.currentPage = newPage;
 
     paginateSearchResults(searchResults, pagination);
@@ -466,22 +468,21 @@ const createHomepageUtils = (_$w, filterProfiles) => {
         currentPageButtonIterator.collapse();
       }
     }
-    if (noOfPages === 0 || noOfPages === 1) {
+    if (totalPages === 0 || totalPages === 1) {
       _$w('#previousPage').disable();
       _$w('#nextPage').disable();
       return;
     }
     if (currentPage === 0) {
       _$w('#previousPage').disable();
-      return;
+    } else {
+      _$w('#previousPage').enable();
     }
-    if (currentPage === noOfPages - 1) {
+    if (currentPage >= totalPages - 1) {
       _$w('#nextPage').disable();
-      return;
+    } else {
+      _$w('#nextPage').enable();
     }
-
-    _$w('#previousPage').enable();
-    _$w('#nextPage').enable();
   }
   function paginateSearchResults(searchResults, pagination) {
     updatePaginationUI(pagination);


### PR DESCRIPTION
## Summary

Fixed a bug where the "Next" pagination button would remain disabled even when search results contained more than one page.

## Problem

When searching for a name that returned multiple pages of results, the Next button would stay disabled, preventing users from navigating to subsequent pages. This was caused by:

1. **Hardcoded max page check**: `handlePagination` used a hardcoded value of `9` instead of the actual `totalPages`
2. **Incorrect last page detection**: `updatePaginationUI` checked against `noOfPages` (capped at 10 for UI display) instead of `totalPages` (actual number of pages)

## Solution

**Fixed `handlePagination` function:**
- Changed from hardcoded `newPage > 9` to `newPage > maxPage` where `maxPage = pagination.totalPages - 1`
- Updated next button logic to use `maxPage` instead of hardcoded `9`

**Fixed `updatePaginationUI` function:**
- Changed last page check from `currentPage === noOfPages - 1` to `currentPage >= totalPages - 1`
- This ensures the next button is correctly disabled only when on the actual last page, regardless of how many pages exist

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Search returns 1 page | Next disabled ✅ | Next disabled ✅ |
| Search returns 2+ pages | Next stays disabled ❌ | Next enabled ✅ |
| Search returns 15 pages | Next disabled at page 10 ❌ | Next enabled until page 15 ✅ |
