### PR TITLE
[Fix] Prevent unchecking primary address checkbox on Personal Details page

### DIFF
--- a/backend/members-data-methods.js
+++ b/backend/members-data-methods.js
@@ -497,9 +497,10 @@ async function getSiteMemberId(data) {
  * @param {Object} params - Parameters
  * @param {string} params.pageName - Name of the page/popup where button was clicked
  * @param {string} params.buttonName - Name/ID of the button that was clicked
+ * @param {Object} [params.data] - Optional data object to store with the click (e.g., form data being saved)
  * @returns {Promise<Object>} - Saved record or null if member not found
  */
-async function trackButtonClick({ pageName, buttonName }) {
+async function trackButtonClick({ pageName, buttonName, data }) {
   const wixMember = await getCurrentMember();
 
   if (!wixMember) {
@@ -525,6 +526,7 @@ async function trackButtonClick({ pageName, buttonName }) {
     pageName,
     buttonName,
     clickedAt: new Date(),
+    ...(data && { data }),
   };
 
   try {

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -1419,7 +1419,7 @@ async function personalDetailsOnReady({
         // If this address is the main address, prevent unchecking
         if (mainAddressOption && mainAddressOption.key === clickedItemData._id) {
           checkbox.checked = true;
-          await wixWindow.openLightbox('mainAddressError');
+          await wixWindow.openLightbox(LIGHTBOX_NAMES.MAIN_ADDRESS_ERROR);
           return;
         }
       }

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -1405,13 +1405,27 @@ async function personalDetailsOnReady({
   }
 
   function setupAddressRepeaterEventListeners() {
-    _$w('#mainAddressCheckbox').onChange(event => {
+    _$w('#mainAddressCheckbox').onChange(async event => {
       const data = _$w('#addressesList').data;
       const clickedItemData = data.find(item => item._id === event.context.itemId);
       const $item = _$w.at(event.context);
+      const checkbox = $item('#mainAddressCheckbox');
+      const isBeingUnchecked = !event.target.checked;
+
+      if (isBeingUnchecked) {
+        const addressDisplayOptions = itemMemberObj.addressDisplayOption || [];
+        const mainAddressOption = addressDisplayOptions.find(opt => opt.isMain === true);
+
+        // If this address is the main address, prevent unchecking
+        if (mainAddressOption && mainAddressOption.key === clickedItemData._id) {
+          checkbox.checked = true;
+          await wixWindow.openLightbox('mainAddressError');
+          return;
+        }
+      }
 
       _$w('#mainAddressCheckbox').checked = false;
-      $item('#mainAddressCheckbox').checked = true;
+      checkbox.checked = true;
 
       if (clickedItemData.address.addressStatus === ADDRESS_STATUS_TYPES.DONT_SHOW) {
         updateAddressStatus(clickedItemData._id, ADDRESS_STATUS_TYPES.STATE_CITY_ZIP);

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -38,6 +38,13 @@ const MAIN_STATE_BOX_STATES = {
 
 const FALLBACK_ADDRESS_STATUS = ADDRESS_STATUS_TYPES.STATE_CITY_ZIP;
 
+const PAGE_NAME = 'Personal Details';
+const BUTTON_NAMES = {
+  PERSONAL: 'Save Personal Details',
+  BUSINESS: 'Save Business & Services',
+  CONTACT: 'Save Contact & Booking',
+};
+
 const FORM_SECTION_HANDLER_MAP = {
   PERSONAL: { section: 'personal', handler: null }, // handler will be set in init
   BUSINESS_SERVICES: { section: 'businessServices', handler: null },
@@ -52,6 +59,7 @@ async function personalDetailsOnReady({
   saveRegistrationData,
   validateMemberToken,
   checkUrlUniqueness,
+  trackClick,
 }) {
   let itemMemberObj = {};
   let originalMemberData = {};
@@ -1094,6 +1102,12 @@ async function personalDetailsOnReady({
       ...personalChanges,
     };
 
+    trackClick({
+      pageName: PAGE_NAME,
+      buttonName: BUTTON_NAMES.PERSONAL,
+      data: formData,
+    });
+
     // Log the specific personal data changes
     console.group('Personal Details Save Attempt');
     console.log('Current Data:', beforeData);
@@ -1136,6 +1150,12 @@ async function personalDetailsOnReady({
       memberId: itemMemberObj.memberId,
       ...businessChanges,
     };
+
+    trackClick({
+      pageName: PAGE_NAME,
+      buttonName: BUTTON_NAMES.BUSINESS,
+      data: formData,
+    });
 
     // Log the specific business data changes
     console.group('Business Services Save Attempt');
@@ -1969,6 +1989,12 @@ async function personalDetailsOnReady({
       memberId: itemMemberObj.memberId,
       ...contactChanges,
     };
+
+    trackClick({
+      pageName: PAGE_NAME,
+      buttonName: BUTTON_NAMES.CONTACT,
+      data: formData,
+    });
 
     // Log the specific contact & booking data changes
     console.group('Contact & Booking Save Attempt');

--- a/public/consts.js
+++ b/public/consts.js
@@ -84,6 +84,7 @@ const LIGHTBOX_NAMES = {
   DELETE_CONFIRM: 'deleteConfirm',
   SELECT_BANNER_IMAGES: 'Select Banner Images',
   CONTACT_US: 'Contact Us',
+  MAIN_ADDRESS_ERROR: 'mainAddressError',
 };
 
 const FREE_WEBSITE_TEXT_STATES = {


### PR DESCRIPTION
Added validation in the `mainAddressCheckbox` onChange handler to:
1. Check if the checkbox is being unchecked
2. Verify if the clicked address is the main address by comparing with `itemMemberObj.addressDisplayOption`
3. If it's the main address, prevent the uncheck action and show the `mainAddressError` lightbox