### PR TITLE
Noindex member profiles when opted out or Wix URL hidden

### DIFF
--- a/backend/routers/methods.js
+++ b/backend/routers/methods.js
@@ -70,9 +70,7 @@ const createRoutersHandlers = wixRouterMethods => {
             {
               name: 'robots',
               content:
-                isPrivateMember || profileData?.optOut || profileData?.showWixUrl === false
-                  ? 'noindex, nofollow'
-                  : 'index, follow',
+                isPrivateMember || profileData?.optOut ? 'noindex, nofollow' : 'index, follow',
             },
             // Open Graph tags
             {

--- a/backend/routers/methods.js
+++ b/backend/routers/methods.js
@@ -69,7 +69,10 @@ const createRoutersHandlers = wixRouterMethods => {
             },
             {
               name: 'robots',
-              content: isPrivateMember ? 'noindex, nofollow' : 'index, follow',
+              content:
+                isPrivateMember || profileData?.optOut || profileData?.showWixUrl === false
+                  ? 'noindex, nofollow'
+                  : 'index, follow',
             },
             // Open Graph tags
             {


### PR DESCRIPTION
Update profile SEO robots meta tag to use `noindex, nofollow` when `optOut` is true or `showWixUrl` is false.

## Why
- Prevent indexing and link following for members who opt out or hide their Wix URL, aligning SEO with privacy intent.