### PR TITLE
include email on trackButtonClick

### DIFF
--- a/backend/members-data-methods.js
+++ b/backend/members-data-methods.js
@@ -550,12 +550,14 @@ async function trackButtonClick({ pageName, buttonName, data }) {
 
   const memberName = dbMember.fullName || 'Unknown';
   const memberId = dbMember.memberId;
+  const memberEmail = dbMember.email;
 
   const clickData = {
     memberName,
     memberId,
     pageName,
     buttonName,
+    memberEmail,
     clickedAt: new Date(),
     ...(data && { data }),
   };


### PR DESCRIPTION
Include an email address column in the ButtonClick collection. This should be visible across all sites (ASCP, ABMP, AHP) in both live and test environments.