### PR TITLE
Default primary address and visibility on daily pull

### DIFF
--- a/backend/daily-pull/process-member-methods.js
+++ b/backend/daily-pull/process-member-methods.js
@@ -1,3 +1,4 @@
+const { ADDRESS_STATUS_TYPES } = require('../../public/consts');
 const { findMemberById, getMemberBySlug } = require('../members-data-methods');
 const { isValidArray, generateGeoHash } = require('../utils');
 
@@ -82,7 +83,16 @@ async function generateUpdatedMemberData({ inputMemberData, currentPageNumber })
 
   // Only add address data for new members
   if (!existingDbMember && isValidArray(inputMemberData.addresses)) {
-    updatedMemberData.addresses = inputMemberData.addresses;
+    const normalizedAddresses = inputMemberData.addresses.map((address, index) => {
+      const key = address?.key || `address_${index}`;
+      return {
+        ...address,
+        key,
+        addressStatus: address?.addressStatus || ADDRESS_STATUS_TYPES.STATE_CITY_ZIP,
+      };
+    });
+    updatedMemberData.addresses = normalizedAddresses;
+    updatedMemberData.addressDisplayOption = [{ key: normalizedAddresses[0].key, isMain: true }];
   }
 
   return { ...updatedMemberData, isNewToDb: !existingDbMember };

--- a/backend/daily-pull/process-member-methods.js
+++ b/backend/daily-pull/process-member-methods.js
@@ -85,10 +85,15 @@ async function generateUpdatedMemberData({ inputMemberData, currentPageNumber })
   if (!existingDbMember && isValidArray(inputMemberData.addresses)) {
     const normalizedAddresses = inputMemberData.addresses.map((address, index) => {
       const key = address?.key || `address_${index}`;
+      const rawStatus = address?.addressStatus;
+      const resolvedStatus =
+        index === 0 && rawStatus === ADDRESS_STATUS_TYPES.DONT_SHOW
+          ? ADDRESS_STATUS_TYPES.STATE_CITY_ZIP
+          : rawStatus || ADDRESS_STATUS_TYPES.STATE_CITY_ZIP;
       return {
         ...address,
         key,
-        addressStatus: address?.addressStatus || ADDRESS_STATUS_TYPES.STATE_CITY_ZIP,
+        addressStatus: resolvedStatus,
       };
     });
     updatedMemberData.addresses = normalizedAddresses;


### PR DESCRIPTION
- Set a primary address for new members by marking the first address in addressDisplayOption.
- Default address visibility to city/state (STATE_CITY_ZIP) when missing.
- Normalize address keys for new member address lists during daily pull.

## Use cases
- Pull a member with no addresses → no changes to address fields.
- Pull a member with one address → address saved, set primary, STATE_CITY_ZIP applied.
- Pull a member with multiple addresses → first marked primary, all get default status if missing.


