### PR TITLE
fix clear toShowPhone when phones are removed and only show phone from router when it’s in phones

### DIFF
--- a/backend/routers/utils.js
+++ b/backend/routers/utils.js
@@ -66,6 +66,11 @@ function transformMemberToProfileData(member, siteAssociation) {
           numeric: true,
         })
       ) || [];
+
+  const phones = Array.isArray(member.phones) ? member.phones : [];
+  const toShowPhone = member.toShowPhone || '';
+  const phone = toShowPhone && phones.includes(toShowPhone) ? toShowPhone : '';
+
   return {
     mainAddress,
     testimonials: member.testimonial || [],
@@ -84,7 +89,7 @@ function transformMemberToProfileData(member, siteAssociation) {
     bookingUrl: member.bookingUrl,
     aboutService: member.aboutService,
     businessName: (member.showBusinessName && member.businessName) || '',
-    phone: member.toShowPhone || '',
+    phone,
     areasOfPractices,
     gallery: member.gallery,
     bannerImages: member.bannerImages,

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -2122,14 +2122,17 @@ async function personalDetailsOnReady({
     const phoneToRemove = currentData.find(item => item._id === phoneId);
 
     if (phoneToRemove) {
-      if (itemMemberObj.toShowPhone === phoneToRemove.phoneNumber) {
-        itemMemberObj.toShowPhone = null;
-      }
-
       if (itemMemberObj.phones) {
         itemMemberObj.phones = itemMemberObj.phones.filter(
           phone => phone !== phoneToRemove.phoneNumber
         );
+      }
+
+      // Clear toShowPhone if it was the removed phone or if it's no longer in the list
+      // (handles format mismatch e.g. "(406)655-4940" vs "(406) 655-4940")
+      const remainingPhones = Array.isArray(itemMemberObj.phones) ? itemMemberObj.phones : [];
+      if (itemMemberObj.toShowPhone && !remainingPhones.includes(itemMemberObj.toShowPhone)) {
+        itemMemberObj.toShowPhone = null;
       }
 
       const updatedData = currentData.filter(item => item._id !== phoneId);
@@ -2152,7 +2155,13 @@ async function personalDetailsOnReady({
   }
 
   function getToShowPhone() {
-    return itemMemberObj.toShowPhone || null;
+    const phones = Array.isArray(itemMemberObj.phones) ? itemMemberObj.phones : [];
+    const toShow = itemMemberObj.toShowPhone || null;
+    // Never expose toShowPhone when phones is empty, so save payload clears it in CMS
+    if (phones.length === 0) return null;
+    // If toShowPhone is not in the list (e.g. format mismatch), treat as none selected
+    if (toShow && !phones.includes(toShow)) return null;
+    return toShow;
   }
 
   function getContactAndBookingData() {


### PR DESCRIPTION
## Summary
Fixes a bug where deleting all phone numbers on the Personal Details page left `toShowPhone` set in the CMS, so the profile page kept showing the old number even though `phones` was empty. Adds a safeguard in profile router data so the displayed phone is only taken from `toShowPhone` when it exists in the `phones` array.

## Problem
- User deletes the only (or last) phone in Personal Details and saves.
- `phones` was correctly saved as `[]`, but `toShowPhone` was not cleared.
- Profile page reads `member.toShowPhone` (exposed as `profileData.phone`) in `backend/routers/utils.js`, so the stale number still appeared.

**Root causes:**
1. **Strict match on remove:** `toShowPhone` was only cleared when `itemMemberObj.toShowPhone === phoneToRemove.phoneNumber`. Slight format differences (e.g. `"(406) 655-4940"` vs `"(406)655-4940"`) prevented clearing.
2. **Save payload:** `getToShowPhone()` could still return the old value when `phones` was empty, so the save request sent `phones: []` but `toShowPhone: "<old number>"` and the backend kept it.

## Solution

### Personal Details (`pages/personalDetails.js`)

**`removePhone()`**
- After filtering the removed phone out of `itemMemberObj.phones`, clear `toShowPhone` if it is **not** in the remaining list (`!remainingPhones.includes(itemMemberObj.toShowPhone)`).
- Handles format mismatch and “last phone removed” without relying on strict string equality.

**`getToShowPhone()`**
- Return `null` when `phones.length === 0` so the save payload always sends `toShowPhone: null` when there are no phones.
- Return `null` when `toShowPhone` is set but not in the `phones` array (invalid/format mismatch), so we never send an invalid “show” phone.

### Profile router data (`backend/routers/utils.js`)
- **Safeguard:** Only set `phone` from `member.toShowPhone` when `toShowPhone` is present **and** it is in `member.phones`.
- If `toShowPhone` is missing or not in the array (e.g. stale data), `phone` is set to `''` so the profile does not show a number.

## Result
- Deleting all phones and saving now persists `phones: []` and `toShowPhone: null` in the CMS.
- Profile page no longer shows a phone when the member has none.
- Even with stale `toShowPhone` in the CMS, the profile will not show a number unless it exists in the `phones` array.

## Files changed
- `pages/personalDetails.js`: `removePhone()`, `getToShowPhone()`
- `backend/routers/utils.js`: profile `phone` derived from `toShowPhone` only when it is in `phones`