### PR TITLE
Fix primary + hidden address visibility for new addresses (repeater sync)

### DIFF
--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -1556,9 +1556,23 @@ async function personalDetailsOnReady({
       _$w('#mainAddressCheckbox').checked = false;
       checkbox.checked = true;
 
+      // Primary address cannot be hidden: update model and repeater data so UI and save stay in sync
       if (clickedItemData.address.addressStatus === ADDRESS_STATUS_TYPES.DONT_SHOW) {
         updateAddressStatus(clickedItemData._id, ADDRESS_STATUS_TYPES.STATE_CITY_ZIP);
         $item('#addressStatusOptions').value = ADDRESS_STATUS_TYPES.STATE_CITY_ZIP;
+        const currentData = _$w('#addressesList').data || [];
+        const dataWithStatusFixed = currentData.map(item =>
+          item._id === clickedItemData._id
+            ? {
+                ...item,
+                address: {
+                  ...item.address,
+                  addressStatus: ADDRESS_STATUS_TYPES.STATE_CITY_ZIP,
+                },
+              }
+            : item
+        );
+        _$w('#addressesList').data = dataWithStatusFixed;
       }
 
       updateMainAddressSelection(clickedItemData._id);

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -1581,7 +1581,7 @@ async function personalDetailsOnReady({
     });
 
     _$w('#addressStatusOptions').onChange(event => {
-      const data = _$w('#addressesList').data;
+      const data = _$w('#addressesList').data || [];
       const clickedItemData = data.find(item => item._id === event.context.itemId);
       const newStatus = event.target.value;
       const $item = _$w.at(event.context);
@@ -1593,6 +1593,15 @@ async function personalDetailsOnReady({
       }
 
       updateAddressStatus(clickedItemData._id, newStatus);
+
+      // Keep repeater data in sync (required for new addresses not yet in itemMemberObj.addresses)
+      const updatedData = data.map(item =>
+        item._id === clickedItemData._id
+          ? { ...item, address: { ...item.address, addressStatus: newStatus } }
+          : item
+      );
+      _$w('#addressesList').data = updatedData;
+
       checkFormChanges(FORM_SECTION_HANDLER_MAP.CONTACT_BOOKING);
     });
 


### PR DESCRIPTION
## Summary
When a user adds a new address, sets it to "Hidden", then marks it primary, the visibility was not switching to "City/State/Zip" for that address. The same flow worked for addresses that already existed in the data. This PR fixes the behavior for addresses that exist only in the repeater (not yet in `itemMemberObj.addresses`).

## Root cause
- **New addresses** live only in the repeater until saved; `updateAddressStatus()` only updates `itemMemberObj.addresses`.
- The logic that forces primary + hidden → City/State/Zip runs when `clickedItemData.address.addressStatus === DONT_SHOW`. For new addresses, the repeater's `address.addressStatus` was never updated when changing the visibility dropdown, so that condition was never true.
- After forcing visibility to City/State/Zip in the primary-checkbox handler, the repeater was not updated, so re-selecting the row could show "Hidden" again because the dropdown was repopulated from repeater data.


##Preview link:
&siteRevision=2&branchId=20ec9215-f480-4d44-bcc3-8bb378ce10b3