### PR TITLE
Handle browser back from Personal Details: redirect to form when session exists instead of login error

### DIFF
--- a/pages/LoadingPage.js
+++ b/pages/LoadingPage.js
@@ -1,6 +1,8 @@
+const { location: wixLocationFrontend } = require('@wix/site-location');
+const { local } = require('@wix/site-storage');
 const { window: wixWindow, rendering } = require('@wix/site-window');
 
-const { LIGHTBOX_NAMES } = require('../public/consts');
+const { LIGHTBOX_NAMES, PAGES_PATHS } = require('../public/consts');
 const { checkAndLogin } = require('../public/sso-auth-methods');
 
 async function loadingPageOnReady(authenticateSSOToken) {
@@ -8,9 +10,16 @@ async function loadingPageOnReady(authenticateSSOToken) {
   //This calls needs to triggered on client side, otherwise PAC API will return 401 error
   if (renderingEnv === 'browser') {
     //Need to pass authenticateSSOToken to checkAndLogin so it will run as a web method not a public one.
-    await checkAndLogin(authenticateSSOToken).catch(error => {
-      wixWindow.openLightbox(LIGHTBOX_NAMES.LOGIN_ERROR_ALERT);
+    await checkAndLogin(authenticateSSOToken).catch(async error => {
       console.error(`Something went wrong while logging in: ${error}`);
+      // If we already have a session (memberId), redirect to form instead of showing error.
+      const storedMemberId = await local.getItem('memberId');
+      if (storedMemberId) {
+        const redirectTo = `${PAGES_PATHS.MEMBERS_FORM}?token=${encodeURIComponent(storedMemberId)}`;
+        await wixLocationFrontend.to(`/${redirectTo}`);
+        return;
+      }
+      wixWindow.openLightbox(LIGHTBOX_NAMES.LOGIN_ERROR_ALERT);
     });
   }
 }


### PR DESCRIPTION
## Summary
When a user was on the Personal Details form and clicked the browser back button, they were taken to the loading page, which then showed "Something went wrong while logging in" instead of returning them to the form. This PR fixes that by redirecting to the form when we already have a valid session (stored memberId at local storage).

## Root cause
- Flow: user lands on `loading-page?token=<sso-token>` → login succeeds → redirect to form (`directory-website-update?token=<memberId>`). History stack: [loading-page] → [form].
- On browser back, the user goes to the previous history entry: `loading-page?token=<sso-token>` again.
- The loading page runs `checkAndLogin()` again without the token from abmp. The call fails and the login error lightbox was shown.


## Testing
- Log in via loading page → reach Personal Details form → click browser back. Expected: brief loading page then redirect back to the form (no "Something went wrong while logging in").