### PR TITLE
Fix profile main address not showing for legacy addresses 

### DIFF
--- a/public/Utils/sharedUtils.js
+++ b/public/Utils/sharedUtils.js
@@ -87,9 +87,11 @@ function findMainAddress(addressDisplayOption = [], addresses = []) {
   return '';
 }
 function formatAddress(item) {
+  if (!item) return '';
   let addressParts = [];
-  const limitedPostalCode = item.postalcode.slice(0, 5); //show only 5 digits to not show full user address
-  switch (item.addressStatus) {
+  const limitedPostalCode = (item.postalcode && String(item.postalcode).slice(0, 5)) || ''; //show only 5 digits to not show full user address
+  const status = item.addressStatus;
+  switch (status) {
     case ADDRESS_STATUS_TYPES.FULL_ADDRESS:
       addressParts = [item.line1, item.line2, item.city, item.state, limitedPostalCode];
       break;
@@ -97,7 +99,10 @@ function formatAddress(item) {
       addressParts = [item.city, item.state, limitedPostalCode];
       break;
     default:
-      return '';
+      if (status === ADDRESS_STATUS_TYPES.DONT_SHOW) return '';
+      // Legacy addresses may have no addressStatus; show city/state/zip by default
+      addressParts = [item.city, item.state, limitedPostalCode];
+      break;
   }
   return addressParts.filter(Boolean).join(', ');
 }


### PR DESCRIPTION
## Summary
On the public profile page, the main address was not displayed when the member's main address had no `addressStatus` (legacy data).  Also fixes formatting so legacy addresses display and ensures `dont_show` addresses are never formatted.

## Root cause
- The main address is chosen by `findMainAddress()` and then formatted with `formatAddress()` in `public/Utils/sharedUtils.js`.
- `formatAddress()` only handled `full_address` and `state_city_zip`. For any other value (including **undefined**), it used `default` and returned `''`, so legacy addresses produced an empty main address.
- There was no explicit handling for `dont_show` in the default branch, so if `formatAddress` were ever called with a hidden address, it could have shown content.

## Changes (public/Utils/sharedUtils.js)

1. **Legacy addresses (no `addressStatus`)**  
   In the `default` branch, treat missing/undefined `addressStatus` as legacy and format as city/state/zip (same as `state_city_zip`) so the main address shows on the profile.

2. **`dont_show`**  
   In the same `default` branch, if `addressStatus === ADDRESS_STATUS_TYPES.DONT_SHOW`, return `''` so hidden addresses are never displayed.

3. **Safety**  
   - Return `''` when `item` is null/undefined.  
   - Build `limitedPostalCode` safely when `postalcode` is missing to avoid calling `.slice()` on undefined.