### PR TITLE
Home page search: debounce, search ID, filter snapshot, and URL sync from applied filter

### DIFF
--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -5,7 +5,17 @@ const { DEFAULT_FILTER } = require('../consts.js');
 
 const { debouncedFunction } = require('./sharedUtils.js');
 
+function generateSearchId() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 const createHomepageUtils = (_$w, filterProfiles) => {
+  let currentSearchId = null;
+
   const getFiltersSelectors = filterName => ({
     checkBoxContainerSelector: _$w(`#${filterName}CheckBoxContainer`),
     searchTextInputSelector: _$w(`#${filterName}TextInput`),
@@ -660,6 +670,9 @@ const createHomepageUtils = (_$w, filterProfiles) => {
     isSearchingNearby,
     preservePagination = false,
   }) {
+    const thisSearchId = generateSearchId();
+    currentSearchId = thisSearchId;
+
     const multiStateBoxSelector = _$w('#resultsStateBox');
     const renderingEnv = await rendering.env();
     const initSearchResultsUI = () => {
@@ -705,6 +718,8 @@ const createHomepageUtils = (_$w, filterProfiles) => {
                 args: { filter, isSearchingNearby },
               });
       const { success, response, error } = await funcPromise();
+      if (thisSearchId !== currentSearchId) return [];
+
       if (!success) {
         _$w('#numberOfResults').text = '';
         console.error('[search] failed with error:', error);


### PR DESCRIPTION
## Summary
This PR fixes wrong results and URL params when users change filters quickly (e.g. select/deselect city, state, or practice area). It adds debounced search with immediate loading, ignores stale responses via a search ID, snapshots the filter for the debounced run, and updates the URL from the filter actually used so the URL stays in sync with the results.

## Problems addressed

1. **Wrong results on rapid filter changes** – Multiple requests could be in flight; the last response to arrive was always applied, so a slower response from an older filter could overwrite correct results.
2. **Too many requests** – Every filter change triggered a request with no debounce, so rapid clicks caused many API calls.
3. **Wrong filter sent** – The filter object is shared and mutated by other code (dropdowns, URL sync). The debounced run could read a filter that had already been changed.
4. **URL params out of sync** – After search completed, the URL was updated with the **live** filter. Rapid select/deselect could leave the live filter without state/city, so the URL ended up missing those params even when the results were correct.

## Changes

### 1. Search ID (ignore stale responses) – `public/Utils/homePage.js`
- **`generateSearchId()`** – Returns a UUID-style string per search.
- **`currentSearchId`** – Holds the id of the latest search.
- When a search is started we set `currentSearchId = generateSearchId()`; when the response returns we only apply it if `thisSearchId === currentSearchId`, otherwise we discard it.
- Ensures only the response for the latest search updates the UI, for any input that triggers search (city, state, practice areas, search text, zip, nearby).

### 2. Debounce with immediate loading – `public/Utils/homePage.js`
- **Loading state** – `initSearchResultsUI()` runs at the start of every `search()` call so loading and cleared results show as soon as the user changes input.
- **Debounced API call (client only)** – We store `lastSearchFilter`, `lastSearchIsSearchingNearby`, `lastSearchPreservePagination` and a single `searchDebounceTimer`. Each new `search()` clears the previous timer and schedules a new run after `DEBOUNCE_DELAY[timeoutType]` (e.g. 300ms filter, 1000ms search, 0 for Apply).
- **Promise handling** – Each `search()` returns a Promise; the previous pending one is resolved with `[]` when superseded; the current one is resolved when the debounced run completes.
- SSR path is unchanged (no debounce).

### 3. Filter snapshot – `public/Utils/homePage.js`
- When scheduling the debounced run we set **`lastSearchFilter = JSON.parse(JSON.stringify(filter))`** instead of keeping a reference.
- The debounced run uses this snapshot so rapid clicks or URL sync cannot change the filter before the request is sent.

### 4. URL updated from filter used – `public/Utils/homePage.js` and `pages/Home.js`
- **Inside `runSearchAndUpdateUI`** we call **`await updateUrlParams(filterToUse, pagination)`** whenever we update the UI: no-search-criteria, error, no-results, and success. The URL is always set from the filter we actually used for that run.
- **In `updateResults` (Home.js)** we removed **`updateUrlParams(filter, pagination)`** after `search()` so the URL is no longer overwritten with the live filter and stays in sync with the applied results.

## Files changed
- `public/Utils/homePage.js` – Search ID, debounce, filter snapshot, URL update in search flow, `DEBOUNCE_DELAY` import (removed `debouncedFunction` usage for search).
- `pages/Home.js` – Removed post-search `updateUrlParams` call in `updateResults`.

## Testing
- Rapid city/state/practice select and deselect: results and URL should match the final selection (e.g. Colorado + Lakewood + Anat Baniel Method).
- Rapid filter changes: only one request after user pauses; loading shows immediately.
- Apply button: still uses zero debounce delay; URL and results stay correct.
- Pagination and other flows that use `updateUrlParams` elsewhere are unchanged.