### PR TITLE
Home page search: debounce, search ID, filter snapshot, and URL sync from applied filter

### DIFF
--- a/pages/Home.js
+++ b/pages/Home.js
@@ -366,7 +366,7 @@ const homePageOnReady = async ({
       isSearchingNearby: _$w('#nearBy').checked,
       preservePagination,
     });
-    !preservePagination && (await updateUrlParams(filter, pagination));
+    // URL is updated inside search() with the filter actually used (avoids rapid select/deselect overwriting with live filter)
     return searchResults;
   }
 

--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -5,7 +5,17 @@ const { DEFAULT_FILTER } = require('../consts.js');
 
 const { debouncedFunction } = require('./sharedUtils.js');
 
+function generateSearchId() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 const createHomepageUtils = (_$w, filterProfiles) => {
+  let currentSearchId = null;
+
   const getFiltersSelectors = filterName => ({
     checkBoxContainerSelector: _$w(`#${filterName}CheckBoxContainer`),
     searchTextInputSelector: _$w(`#${filterName}TextInput`),
@@ -660,6 +670,9 @@ const createHomepageUtils = (_$w, filterProfiles) => {
     isSearchingNearby,
     preservePagination = false,
   }) {
+    const thisSearchId = generateSearchId();
+    currentSearchId = thisSearchId;
+
     const multiStateBoxSelector = _$w('#resultsStateBox');
     const renderingEnv = await rendering.env();
     const initSearchResultsUI = () => {
@@ -705,6 +718,8 @@ const createHomepageUtils = (_$w, filterProfiles) => {
                 args: { filter, isSearchingNearby },
               });
       const { success, response, error } = await funcPromise();
+      if (thisSearchId !== currentSearchId) return [];
+
       if (!success) {
         _$w('#numberOfResults').text = '';
         console.error('[search] failed with error:', error);

--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -1,9 +1,7 @@
 const { location: wixLocation, queryParams: wixQueryParams } = require('@wix/site-location');
 const { window: wixWindow, rendering } = require('@wix/site-window');
 
-const { DEFAULT_FILTER } = require('../consts.js');
-
-const { debouncedFunction } = require('./sharedUtils.js');
+const { DEFAULT_FILTER, DEBOUNCE_DELAY } = require('../consts.js');
 
 function generateSearchId() {
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
@@ -15,6 +13,11 @@ function generateSearchId() {
 
 const createHomepageUtils = (_$w, filterProfiles) => {
   let currentSearchId = null;
+  let searchDebounceTimer = null;
+  let lastSearchFilter = null;
+  let lastSearchIsSearchingNearby = false;
+  let lastSearchPreservePagination = false;
+  let pendingSearchResolve = null;
 
   const getFiltersSelectors = filterName => ({
     checkBoxContainerSelector: _$w(`#${filterName}CheckBoxContainer`),
@@ -665,16 +668,14 @@ const createHomepageUtils = (_$w, filterProfiles) => {
   async function search({
     filter,
     pagination,
-    debounceTimeout,
+    debounceTimeout: _debounceTimeout,
     timeoutType,
     isSearchingNearby,
     preservePagination = false,
   }) {
-    const thisSearchId = generateSearchId();
-    currentSearchId = thisSearchId;
-
     const multiStateBoxSelector = _$w('#resultsStateBox');
     const renderingEnv = await rendering.env();
+
     const initSearchResultsUI = () => {
       JSON.stringify(filter) === JSON.stringify(DEFAULT_FILTER)
         ? _$w('#resetFilter').hide()
@@ -685,72 +686,115 @@ const createHomepageUtils = (_$w, filterProfiles) => {
       _$w('#profileRepeater').data = [];
       console.log({ filter });
     };
-    const runSearchAndUpdateUI = async (filter, isSearchingNearby) => {
-      if (!isSearchingNearby) {
+
+    const runSearchAndUpdateUI = async (
+      filterToUse,
+      isSearchingNearbyToUse,
+      preservePaginationToUse
+    ) => {
+      if (!isSearchingNearbyToUse) {
         if (
           JSON.stringify({
-            ...filter,
+            ...filterToUse,
             latitude: 0,
             longitude: 0,
           }) === JSON.stringify(DEFAULT_FILTER)
         ) {
           multiStateBoxSelector.changeState('noSearchCriteria');
+          await updateUrlParams(filterToUse, pagination);
           return [];
         }
       }
-      const nonDebouncedFilterProfiles = async () => {
-        try {
-          const result = await filterProfiles({ filter, isSearchingNearby });
-          return { success: true, response: result };
-        } catch (error) {
-          return { success: false, error };
-        }
-      };
-      //Don't run setTimeout on SSR
-      const funcPromise =
-        renderingEnv === 'backend'
-          ? () => nonDebouncedFilterProfiles()
-          : () =>
-              debouncedFunction({
-                func: filterProfiles,
-                debounceTimeout,
-                timeoutType,
-                args: { filter, isSearchingNearby },
-              });
-      const { success, response, error } = await funcPromise();
-      if (thisSearchId !== currentSearchId) return [];
+      const thisSearchId = generateSearchId();
+      currentSearchId = thisSearchId;
 
-      if (!success) {
+      let result;
+      try {
+        result = await filterProfiles({
+          filter: filterToUse,
+          isSearchingNearby: isSearchingNearbyToUse,
+        });
+      } catch (error) {
+        if (thisSearchId !== currentSearchId) return [];
         _$w('#numberOfResults').text = '';
         console.error('[search] failed with error:', error);
         multiStateBoxSelector.changeState('errorState');
+        await updateUrlParams(filterToUse, pagination);
         return [];
       }
+
+      if (thisSearchId !== currentSearchId) return [];
+
+      const response = result;
       const totalCount = response.items.length;
       if (!totalCount) {
         _$w('#numberOfResults').text = 'Showing 0 results';
         _$w('#noResultsMessage').text = `${
-          filter.searchText && filter.searchText.length > 0
-            ? `'${filter.searchText}' did not match any search. Please try again.`
+          filterToUse.searchText && filterToUse.searchText.length > 0
+            ? `'${filterToUse.searchText}' did not match any search. Please try again.`
             : 'No results found for the selected filters. Please adjust your filters and try again'
         }`;
         multiStateBoxSelector.changeState('noResultsState');
+        await updateUrlParams(filterToUse, pagination);
         return [];
       }
       console.log({ response });
       handleNumberOfResults(pagination, totalCount);
       _$w('#showingResult').show();
 
-      if (!preservePagination || pagination.currentPage >= pagination.totalPages) {
+      if (!preservePaginationToUse || pagination.currentPage >= pagination.totalPages) {
         pagination.currentPage = 0;
       }
       pagination.totalPages = Math.ceil(totalCount / pagination.pageSize);
       paginateSearchResults(response.items, pagination);
       multiStateBoxSelector.changeState('resultsState');
+      await updateUrlParams(filterToUse, pagination);
       return response.items;
     };
+
+    // Always show loading as soon as user changes input
     initSearchResultsUI();
-    return await runSearchAndUpdateUI(filter, isSearchingNearby);
+
+    // SSR: run immediately, no debounce
+    if (renderingEnv === 'backend') {
+      return await runSearchAndUpdateUI(filter, isSearchingNearby, preservePagination);
+    }
+
+    // Client: debounce the API call; loading is already shown above.
+    // Snapshot the filter so rapid clicks / URL sync can't mutate it before the debounced run.
+    lastSearchFilter = JSON.parse(JSON.stringify(filter));
+    lastSearchIsSearchingNearby = isSearchingNearby;
+    lastSearchPreservePagination = preservePagination;
+
+    if (pendingSearchResolve) {
+      pendingSearchResolve([]);
+      pendingSearchResolve = null;
+    }
+
+    if (searchDebounceTimer) {
+      clearTimeout(searchDebounceTimer);
+      searchDebounceTimer = null;
+    }
+
+    const delay = DEBOUNCE_DELAY[timeoutType] ?? 300;
+    return new Promise(resolve => {
+      pendingSearchResolve = resolve;
+      searchDebounceTimer = setTimeout(async () => {
+        searchDebounceTimer = null;
+        const filterToUse = lastSearchFilter;
+        const isSearchingNearbyToUse = lastSearchIsSearchingNearby;
+        const preservePaginationToUse = lastSearchPreservePagination;
+        const items = await runSearchAndUpdateUI(
+          filterToUse,
+          isSearchingNearbyToUse,
+          preservePaginationToUse
+        );
+        if (pendingSearchResolve) {
+          pendingSearchResolve(items);
+          pendingSearchResolve = null;
+        }
+      }, delay);
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary
This PR fixes wrong results and URL params when users change filters quickly (e.g. select/deselect city, state, or practice area). It adds debounced search with immediate loading, ignores stale responses via a search ID, snapshots the filter for the debounced run, and updates the URL from the filter actually used so the URL stays in sync with the results.

## Problems addressed

1. **Wrong results on rapid filter changes** – Multiple requests could be in flight; the last response to arrive was always applied, so a slower response from an older filter could overwrite correct results.
2. **Too many requests** – Every filter change triggered a request with no debounce, so rapid clicks caused many API calls.
3. **Wrong filter sent** – The filter object is shared and mutated by other code (dropdowns, URL sync). The debounced run could read a filter that had already been changed.
4. **URL params out of sync** – After search completed, the URL was updated with the **live** filter. Rapid select/deselect could leave the live filter without state/city, so the URL ended up missing those params even when the results were correct.

## Changes

### 1. Search ID (ignore stale responses) – `public/Utils/homePage.js`
- **`generateSearchId()`** – Returns a UUID-style string per search.
- **`currentSearchId`** – Holds the id of the latest search.
- When a search is started we set `currentSearchId = generateSearchId()`; when the response returns we only apply it if `thisSearchId === currentSearchId`, otherwise we discard it.
- Ensures only the response for the latest search updates the UI, for any input that triggers search (city, state, practice areas, search text, zip, nearby).

### 2. Debounce with immediate loading – `public/Utils/homePage.js`
- **Loading state** – `initSearchResultsUI()` runs at the start of every `search()` call so loading and cleared results show as soon as the user changes input.
- **Debounced API call (client only)** – We store `lastSearchFilter`, `lastSearchIsSearchingNearby`, `lastSearchPreservePagination` and a single `searchDebounceTimer`. Each new `search()` clears the previous timer and schedules a new run after `DEBOUNCE_DELAY[timeoutType]` (e.g. 300ms filter, 1000ms search, 0 for Apply).
- **Promise handling** – Each `search()` returns a Promise; the previous pending one is resolved with `[]` when superseded; the current one is resolved when the debounced run completes.
- SSR path is unchanged (no debounce).

### 3. Filter snapshot – `public/Utils/homePage.js`
- When scheduling the debounced run we set **`lastSearchFilter = JSON.parse(JSON.stringify(filter))`** instead of keeping a reference.
- The debounced run uses this snapshot so rapid clicks or URL sync cannot change the filter before the request is sent.

### 4. URL updated from filter used – `public/Utils/homePage.js` and `pages/Home.js`
- **Inside `runSearchAndUpdateUI`** we call **`await updateUrlParams(filterToUse, pagination)`** whenever we update the UI: no-search-criteria, error, no-results, and success. The URL is always set from the filter we actually used for that run.
- **In `updateResults` (Home.js)** we removed **`updateUrlParams(filter, pagination)`** after `search()` so the URL is no longer overwritten with the live filter and stays in sync with the applied results.

## Files changed
- `public/Utils/homePage.js` – Search ID, debounce, filter snapshot, URL update in search flow, `DEBOUNCE_DELAY` import (removed `debouncedFunction` usage for search).
- `pages/Home.js` – Removed post-search `updateUrlParams` call in `updateResults`.

## Testing
- Rapid city/state/practice select and deselect: results and URL should match the final selection (e.g. Colorado + Lakewood + Anat Baniel Method).
- Rapid filter changes: only one request after user pauses; loading shows immediately.
- Apply button: still uses zero debounce delay; URL and results stay correct.
- Pagination and other flows that use `updateUrlParams` elsewhere are unchanged.