### PR TITLE
Fix double slash in S3 sitemap profile URLs

### DIFF
--- a/backend/tasks/tasks-helpers-methods.js
+++ b/backend/tasks/tasks-helpers-methods.js
@@ -295,7 +295,7 @@ async function getAWSTokens() {
 }
 
 async function generateSitemapXml(members) {
-  const baseUrl = await getSiteBaseUrl();
+  const baseUrl = (await getSiteBaseUrl()).replace(/\/+$/, '');
   const profilePageUrl = `${baseUrl}/${PAGES_PATHS.PROFILE}`;
   const urls = members
     .map(m => {


### PR DESCRIPTION
### Problem
Profile URLs in the S3 sitemap were generated with a double slash after the domain (e.g. `https://www.abmpmembers.com//profile/MemberSlug`). This came from concatenating a base URL that already had a trailing slash with paths that start with `/`.

### Solution
In `generateSitemapXml()` (backend/tasks/tasks-helpers-methods.js), the base URL from `getSiteBaseUrl()` is normalized by stripping trailing slashes before building profile URLs:

```js
const baseUrl = (await getSiteBaseUrl()).replace(/\/+$/, '');
```

So whether the Wix API returns a base URL with or without a trailing slash, sitemap `<loc>` values are built with a single slash (e.g. `https://www.abmpmembers.com/profile/MemberSlug`).

### Impact
- Sitemap XML uploaded to S3 by `updateSiteMapS3` now has correct, single-slash profile URLs.
- No other behavior changed; only URL formatting in the generated sitemap.