### PR TITLE
Show main address on profile and home without requiring coordinates

### DIFF
--- a/backend/cms-data-methods.js
+++ b/backend/cms-data-methods.js
@@ -148,7 +148,9 @@ function buildMembersSearchQuery(data) {
               latitude: filter.latitude,
               longitude: filter.longitude,
             },
-            findMainAddress(item.addressDisplayOption, item.addresses)
+            findMainAddress(item.addressDisplayOption, item.addresses, {
+              requireValidCoordinates: true,
+            })
           ),
         }));
         const resultWithDistances = {

--- a/public/Utils/sharedUtils.js
+++ b/public/Utils/sharedUtils.js
@@ -73,13 +73,13 @@ function findMainAddress(addressDisplayOption = [], addresses = []) {
     const mainAddr = addresses.find(
       addr => addr.key === mainOpt.key && addr.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW
     );
-    if (mainAddr && isValidLocation(mainAddr)) {
+    if (mainAddr) {
       return mainAddr;
     }
   }
   // 2) fallback: if there is any visible address, use it
   const visibleAddresses = addresses.filter(
-    addr => addr.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW && isValidLocation(addr)
+    addr => addr.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW
   );
   if (visibleAddresses.length) {
     return visibleAddresses[0];

--- a/public/Utils/sharedUtils.js
+++ b/public/Utils/sharedUtils.js
@@ -66,20 +66,31 @@ function debouncedFunction({ func, debounceTimeout, timeoutType, args }) {
 
 const isValidLocation = location => location.latitude && location.longitude;
 
-function findMainAddress(addressDisplayOption = [], addresses = []) {
-  const options = Array.isArray(addressDisplayOption) ? addressDisplayOption : [];
-  const mainOpt = options.find(opt => opt.isMain);
+/**
+ * @param {Array} addressDisplayOption
+ * @param {Array} addresses
+ * @param {Object|boolean} [options] - Optional. Pass { requireValidCoordinates: true } for home search/distance; omit or false for profile display.
+ */
+function findMainAddress(addressDisplayOption = [], addresses = [], options = {}) {
+  const requireValidCoordinates =
+    typeof options === 'boolean' ? options : Boolean(options?.requireValidCoordinates);
+  const optionsArr = Array.isArray(addressDisplayOption) ? addressDisplayOption : [];
+  const mainOpt = optionsArr.find(opt => opt.isMain);
   if (mainOpt) {
     const mainAddr = addresses.find(
-      addr => addr.key === mainOpt.key && addr.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW
+      addr =>
+        addr.key === mainOpt.key &&
+        addr.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW &&
+        (!requireValidCoordinates || isValidLocation(addr))
     );
     if (mainAddr) {
       return mainAddr;
     }
   }
-  // 2) fallback: if there is any visible address, use it
   const visibleAddresses = addresses.filter(
-    addr => addr.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW
+    addr =>
+      addr.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW &&
+      (!requireValidCoordinates || isValidLocation(addr))
   );
   if (visibleAddresses.length) {
     return visibleAddresses[0];
@@ -107,8 +118,13 @@ function formatAddress(item) {
   return addressParts.filter(Boolean).join(', ');
 }
 
-function getMainAddress(addressDisplayOption = [], addresses = []) {
-  const mainAddr = findMainAddress(addressDisplayOption, addresses);
+/**
+ * @param {Array} addressDisplayOption
+ * @param {Array} addresses
+ * @param {Object|boolean} [options] - Optional. Pass { requireValidCoordinates: true } for home search/distance; omit or false for profile display.
+ */
+function getMainAddress(addressDisplayOption = [], addresses = [], options = {}) {
+  const mainAddr = findMainAddress(addressDisplayOption, addresses, options);
   if (mainAddr) {
     return formatAddress(mainAddr);
   }


### PR DESCRIPTION
## Summary
Addresses with missing or zero coordinates (`latitude: 0`, `longitude: 0`) were excluded from profile display. We now show the main address (and more addresses) on the **profile** based only on visibility, while **home search and cards** still require valid coordinates for location text, distance, and maps.

## Problem
- **Profile page:** `mainAddress` and `moreAddressesToDisplay` were empty when the member’s address had no valid lat/lng (e.g. daily pull or Wix Address Input not resolving).
- **Home search:** Should be unchanged—distance and location still depend on valid coordinates.

## Solution
- **`findMainAddress(addressDisplayOption, addresses, options)`** and **`getMainAddress(..., options)`** in `public/Utils/sharedUtils.js` now accept an optional third argument:
  - **`options.requireValidCoordinates`** (or third param as boolean):
    - **`true`** – Only return an address when it has valid `latitude`/`longitude` (used for home search and distance).
    - **`false`** or omitted – Return the visible main address regardless of coordinates (used for profile display).
- **Call sites:**
  - **Profile:** `backend/routers/utils.js` and `backend/utils.js` (getMoreAddressesToDisplay) call with no third argument → default `requireValidCoordinates: false` → profile shows address even when coords are 0 or missing.
  - **Home search/cards:** `pages/Home.js` calls `getMainAddress(..., { requireValidCoordinates: true })` → location text only when the main address has valid coordinates (unchanged behavior).
  - **Search/distance:** `backend/cms-data-methods.js` calls `findMainAddress(..., { requireValidCoordinates: true })` when computing distance for “search nearby” → distance only for addresses with valid coordinates.

## Result
- Profile shows main address and additional addresses even when coordinates are missing or zero.
- Home search and result cards keep previous behavior: location text, “Show maps,” and distance only when addresses have valid coordinates.
- Backward compatible: callers that don’t pass the flag get the profile-style behavior (no coordinate check).