### PR TITLE
correlate responses with search ID to ignore stale results

### DIFF
--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -5,7 +5,37 @@ const { DEFAULT_FILTER } = require('../consts.js');
 
 const { debouncedFunction } = require('./sharedUtils.js');
 
+/** Returned when an in-flight search was superseded; do not apply results to UI */
+const STALE_SEARCH_RESPONSE = Symbol('STALE_SEARCH_RESPONSE');
+
+function generateSearchId() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 const createHomepageUtils = (_$w, filterProfiles) => {
+  let currentSearchId = null;
+
+  async function fetchProfilesWithSearchId(args) {
+    const thisSearchId = generateSearchId();
+    currentSearchId = thisSearchId;
+    try {
+      const response = await filterProfiles(args);
+      if (thisSearchId !== currentSearchId) {
+        return STALE_SEARCH_RESPONSE;
+      }
+      return response;
+    } catch (error) {
+      if (thisSearchId !== currentSearchId) {
+        return STALE_SEARCH_RESPONSE;
+      }
+      throw error;
+    }
+  }
+
   const getFiltersSelectors = filterName => ({
     checkBoxContainerSelector: _$w(`#${filterName}CheckBoxContainer`),
     searchTextInputSelector: _$w(`#${filterName}TextInput`),
@@ -687,7 +717,10 @@ const createHomepageUtils = (_$w, filterProfiles) => {
       }
       const nonDebouncedFilterProfiles = async () => {
         try {
-          const result = await filterProfiles({ filter, isSearchingNearby });
+          const result = await fetchProfilesWithSearchId({ filter, isSearchingNearby });
+          if (result === STALE_SEARCH_RESPONSE) {
+            return { success: true, response: STALE_SEARCH_RESPONSE };
+          }
           return { success: true, response: result };
         } catch (error) {
           return { success: false, error };
@@ -699,12 +732,15 @@ const createHomepageUtils = (_$w, filterProfiles) => {
           ? () => nonDebouncedFilterProfiles()
           : () =>
               debouncedFunction({
-                func: filterProfiles,
+                func: fetchProfilesWithSearchId,
                 debounceTimeout,
                 timeoutType,
                 args: { filter, isSearchingNearby },
               });
       const { success, response, error } = await funcPromise();
+      if (response === STALE_SEARCH_RESPONSE) {
+        return [];
+      }
       if (!success) {
         _$w('#numberOfResults').text = '';
         console.error('[search] failed with error:', error);


### PR DESCRIPTION
## Summary
Adds a **search correlation ID** to the member directory home search so that when several `filterProfiles` runs overlap (e.g. fast filter or URL-driven changes), **only the latest request** can update the UI. Older responses are discarded instead of overwriting the list.

## Problem
Without correlation, a slower request can finish **after** a newer one and repopulate the repeater with **out-of-date results**, while the URL or filter UI reflect the latest choice.

## Solution (`public/Utils/homePage.js`)
- **`generateSearchId()`** – UUID-style id per request batch.
- **`currentSearchId`** – Updated whenever a new search **starts** the real `filterProfiles` call (inside `fetchProfilesWithSearchId`).
- **`fetchProfilesWithSearchId(args)`** – Assigns id, calls `filterProfiles`, then if `thisSearchId !== currentSearchId` returns **`STALE_SEARCH_RESPONSE`** (and does the same when errors occur after the search was superseded).
- **SSR** – `nonDebouncedFilterProfiles` uses `fetchProfilesWithSearchId` instead of calling `filterProfiles` directly.
- **Client** – `debouncedFunction` now wraps **`fetchProfilesWithSearchId`** (same debounce keys/delays as before).
- After the awaited promise, if the result is **`STALE_SEARCH_RESPONSE`**, return **`[]`** and **do not** change results/error/empty UI so a stale payload cannot flash on screen.

## Scope
- **Only search ID** — no change to debounce timing, filter snapshot, or URL update logic.

## Testing
- Rapidly change filters (e.g. state/city) and confirm the list always matches the **last** completed interaction, not an earlier one.
- Smoke-test `nearby` and initial load (SSR + browser).