### PR TITLE
Normalize member website and booking URLs

### DIFF
--- a/pages/Home.js
+++ b/pages/Home.js
@@ -10,6 +10,7 @@ const {
   formatPracticeAreasForDisplay,
   checkAddressIsVisible,
   isWixHostedImage,
+  normalizeExternalUrl,
 } = require('../public/Utils/sharedUtils.js');
 
 let filter = JSON.parse(JSON.stringify(DEFAULT_FILTER));
@@ -198,7 +199,7 @@ const homePageOnReady = async ({
         $item('#websiteContainer').collapse();
       } else {
         if (itemData.showWebsite) {
-          $item('#website').link = itemData.website;
+          $item('#website').link = normalizeExternalUrl(itemData.website);
         } else {
           $item('#website').link = `${baseUrl}/profile/${itemData.url}`;
         }
@@ -256,7 +257,7 @@ const homePageOnReady = async ({
       // 9) "Book now" button
       if (itemData.bookingUrl) {
         $item('#bookNowButton').show();
-        $item('#bookNowButton').link = itemData.bookingUrl;
+        $item('#bookNowButton').link = normalizeExternalUrl(itemData.bookingUrl);
         $item('#bookNowButton').target = '_blank';
       } else {
         $item('#bookNowButton').hide();

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -9,7 +9,11 @@ const {
   LIGHTBOX_NAMES,
 } = require('../public/consts');
 const { handleOnCustomValidation, isNotValidUrl } = require('../public/Utils/personalDetailsUtils');
-const { generateId, isWixHostedImage } = require('../public/Utils/sharedUtils');
+const {
+  generateId,
+  isWixHostedImage,
+  normalizeExternalUrl,
+} = require('../public/Utils/sharedUtils');
 
 const MAX_PHONES_COUNT = 10;
 const MAX_ADDRESSES_COUNT = 10;
@@ -2216,12 +2220,15 @@ async function personalDetailsOnReady({
     const addresses = Array.isArray(itemMemberObj.addresses) ? itemMemberObj.addresses : [];
     const phones = Array.isArray(itemMemberObj.phones) ? itemMemberObj.phones : [];
 
+    const rawWebsite = (_$w('#UrlInput').value || '').trim();
+    const rawBooking = (_$w('#schedulingLinkInput').value || '').trim();
+
     return {
       showContactForm: _$w('#showCotactFormCheckbox').checked,
       contactFormEmail: _$w('#contactFormEmailInput').value,
       toShowPhone: getToShowPhone(),
-      bookingUrl: _$w('#schedulingLinkInput').value,
-      website: _$w('#UrlInput').value,
+      bookingUrl: rawBooking ? normalizeExternalUrl(rawBooking) : '',
+      website: rawWebsite ? normalizeExternalUrl(rawWebsite) : '',
       showWebsite: showExistingUrl,
       showWixUrl,
       addresses,

--- a/public/Utils/sharedUtils.js
+++ b/public/Utils/sharedUtils.js
@@ -186,6 +186,15 @@ function isWixHostedImage(imageUrl) {
   );
 }
 
+/** Web URLs only: bare hostnames get https:// so they are not treated as site-relative paths. */
+function normalizeExternalUrl(url) {
+  if (!url || typeof url !== 'string') return url;
+  const trimmed = url.trim();
+  if (!trimmed) return trimmed;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  return `https://${trimmed}`;
+}
+
 module.exports = {
   checkAddressIsVisible,
   formatPracticeAreasForDisplay,
@@ -198,4 +207,5 @@ module.exports = {
   generateId,
   formatAddress,
   isWixHostedImage,
+  normalizeExternalUrl,
 };


### PR DESCRIPTION
#### Summary

Members often enter values like `www.example.com` without a scheme. Browsers then treat those strings as **paths on the current site**, so “Website” and “Book now” on the home search repeater did not open the intended external URL. This change normalizes those values to full web URLs and applies the same logic when saving Contact & Booking on Personal Details so stored CMS data stays consistent.

#### Changes

- **`public/Utils/sharedUtils.js`**  
  - Add **`normalizeExternalUrl`**: trim; if the value already starts with `http://` or `https://`, leave it unchanged; otherwise prepend **`https://`**.

- **`pages/Home.js`**  
  - Use **`normalizeExternalUrl`** when setting the repeater **Website** link (custom URL) and **Book now** link so search results behave correctly for existing records that only have a hostname.

- **`pages/personalDetails.js`**  
  - In **`getContactAndBookingData`**, normalize non-empty **`website`** (`#UrlInput`) and **`bookingUrl`** (`#schedulingLinkInput`) before save so new edits are stored in canonical form.

#### Testing

- [ ] Personal Details → Contact & Booking: save “Other website” as `www.wix.com` (or similar), confirm CMS stores `https://www.wix.com`.
- [ ] Home search: open a result with a custom website; confirm the Website button opens the external site in a new tab/window as expected.
- [ ] Same for **Book now** when a scheduling URL is entered without `https://`.