### PR TITLE
Fix Show your phone repeater

### DIFF
--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -2039,9 +2039,14 @@ async function personalDetailsOnReady({
         return;
       }
 
+      const $item = _$w.at(event.context);
       const isChecked = event.target.checked;
       let updated;
       if (isChecked) {
+        // Same pattern as #mainAddressCheckbox: clear every row, then select one (repeater
+        // often does not refresh sibling items' controls when only `data` changes).
+        _$w('#showPhoneCheckbox').checked = false;
+        $item('#showPhoneCheckbox').checked = true;
         updated = data.map(item =>
           item._id === clickedItemData._id
             ? { ...item, showPhone: true }
@@ -2094,6 +2099,34 @@ async function personalDetailsOnReady({
     $item('#phoneNumberLabel').text = `Phone ${itemData.phoneIndex}`;
   }
 
+  /** Only one "Show your phone" row at a time; aligns UI with itemMemberObj.toShowPhone. */
+  function normalizePhoneShowFlags(phoneData) {
+    if (!phoneData?.length) return phoneData;
+
+    const cms = (itemMemberObj.toShowPhone || '').trim();
+    if (cms) {
+      let matched = false;
+      return phoneData.map(p => {
+        const t = (p.phoneNumber || '').trim();
+        const isMatch = Boolean(t && t === cms);
+        if (isMatch && !matched) {
+          matched = true;
+          return { ...p, showPhone: true };
+        }
+        return { ...p, showPhone: false };
+      });
+    }
+
+    const trueIdxs = phoneData.map((p, i) => (p.showPhone ? i : -1)).filter(i => i >= 0);
+    if (trueIdxs.length <= 1) return phoneData;
+
+    const keep = trueIdxs[0];
+    return phoneData.map((p, i) => ({
+      ...p,
+      showPhone: i === keep,
+    }));
+  }
+
   function renderPhonesList(updatedPhones) {
     let phoneData = updatedPhones || [];
 
@@ -2109,10 +2142,26 @@ async function personalDetailsOnReady({
       }));
     }
 
+    phoneData = normalizePhoneShowFlags(phoneData);
+
     const repeater = _$w('#phoneNumbersList');
 
     repeater.data = phoneData;
+    refreshPhoneShowCheckboxState(phoneData);
     updatePhoneAddButtonState();
+  }
+
+  /**
+   * Repeater may not re-run onItemReady for sibling items when only showPhone flags change;
+   * keep each #showPhoneCheckbox in sync with data (same idea as refreshAddressListIsMainState).
+   */
+  function refreshPhoneShowCheckboxState(phoneData) {
+    const repeater = _$w('#phoneNumbersList');
+    const data = phoneData || repeater.data || [];
+    repeater.forEachItem(($item, _itemData, index) => {
+      const show = index < data.length ? data[index].showPhone : false;
+      $item('#showPhoneCheckbox').checked = Boolean(show);
+    });
   }
 
   function updatePhoneAddButtonState() {
@@ -2131,7 +2180,22 @@ async function personalDetailsOnReady({
     const itemIndex = currentData.findIndex(item => item._id === phoneId);
 
     if (itemIndex !== -1) {
-      currentData[itemIndex].phoneNumber = newPhoneNumber;
+      const item = currentData[itemIndex];
+      const prevTrimmed = (item.phoneNumber || '').trim();
+      const newTrimmed = newPhoneNumber.trim();
+
+      item.phoneNumber = newPhoneNumber;
+
+      if (item.showPhone) {
+        itemMemberObj.toShowPhone = newTrimmed || null;
+      } else if (
+        itemMemberObj.toShowPhone &&
+        prevTrimmed &&
+        itemMemberObj.toShowPhone === prevTrimmed
+      ) {
+        itemMemberObj.toShowPhone = newTrimmed || null;
+      }
+
       renderPhonesList(currentData);
       syncPhonesFromRepeater();
       checkFormChanges(FORM_SECTION_HANDLER_MAP.CONTACT_BOOKING);
@@ -2187,14 +2251,14 @@ async function personalDetailsOnReady({
       return;
     }
 
+    const trimmed = (selectedItem.phoneNumber || '').trim();
+
     if (isVisible) {
-      itemMemberObj.toShowPhone = selectedItem.phoneNumber?.trim()
-        ? selectedItem.phoneNumber
-        : null;
+      itemMemberObj.toShowPhone = trimmed || null;
       return;
     }
 
-    if (selectedItem.phoneNumber) {
+    if (itemMemberObj.toShowPhone === trimmed) {
       itemMemberObj.toShowPhone = null;
     }
   }


### PR DESCRIPTION
#### Summary

The Contact & Booking phone repeater had several related problems: more than one “Show your phone” checkbox could appear selected, editing the number that was marked for display could clear **`toShowPhone`** on save, and unchecking behavior did not always align with **`toShowPhone`**. The address repeater already solves a similar problem (main location + repeater quirks); this work applies the same ideas to phones.

#### What changed

- **Single selection in data** — **`normalizePhoneShowFlags`** ensures at most one row has **`showPhone: true`**, driven by **`itemMemberObj.toShowPhone`** when set, otherwise collapsing duplicate **`true`** flags to the first row.
- **Keep `toShowPhone` when the displayed number is edited** — In **`updatePhoneNumber`**, when the row is the visible one (**`showPhone`**) or when **`toShowPhone`** still matched the previous trimmed value, update **`itemMemberObj.toShowPhone`** to the new trimmed value so **`getToShowPhone()`** does not return **`null`** after a harmless edit.
- **Uncheck handling** — **`updateShowPhoneSelection`** clears **`toShowPhone`** when it matches the unchecked row’s trimmed number; checking stores a trimmed value consistently.
- **Match main-address behavior in the UI** — On check, clear all **`#showPhoneCheckbox`** instances on the repeater, then set only the clicked row’s checkbox (**`_$w.at(event.context)`**), mirroring **`#mainAddressCheckbox`**.
- **Sync checkboxes after `repeater.data` updates** — **`refreshPhoneShowCheckboxState`** uses **`forEachItem`** so every row’s checkbox matches **`showPhone`** in data (Wix repeaters often do not refresh sibling items when only **`data`** changes).


#### How to test

- [ ] use preview params: &siteRevision=2&branchId=84e3c1bf-84d2-4ace-ab70-80655e3f27dc
- [ ] Add two phones; select “Show your phone” on one, then the other — only one checkbox stays checked and **`toShowPhone`** matches the selected number.
- [ ] With one phone selected for display, change that number — save still sends the updated number as **`toShowPhone`** (not cleared).
- [ ] Uncheck “Show your phone” — **`toShowPhone`** clears appropriately.
- [ ] Reload the form — selection still matches CMS.