### PR TITLE
Add daily pull execution check with fallback reschedule

### DIFF
--- a/backend/jobs.js
+++ b/backend/jobs.js
@@ -2,6 +2,7 @@ const { taskManager } = require('psdev-task-manager');
 
 const { MEMBER_ACTIONS } = require('./daily-pull/consts');
 const { TASKS_NAMES } = require('./tasks/consts');
+const { dailyPullExecutionCheck } = require('./tasks/daily-pull-check-methods');
 const { TASKS } = require('./tasks/tasks-configs');
 
 async function runScheduledTasks() {
@@ -96,17 +97,13 @@ async function scheduleFixUrlsWithSpacesTask() {
   }
 }
 
-async function scheduleDailyPullExecutionCheckTask() {
+async function runDailyPullExecutionCheck() {
   try {
-    console.log('scheduleDailyPullExecutionCheck started!');
-    return await taskManager().schedule({
-      name: TASKS_NAMES.scheduleDailyPullExecutionCheck,
-      data: {},
-      type: 'scheduled',
-    });
+    console.log('runDailyPullExecutionCheck started!');
+    return await dailyPullExecutionCheck({});
   } catch (error) {
-    console.error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
-    throw new Error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
+    console.error(`Failed to runDailyPullExecutionCheck: ${error.message}`);
+    throw new Error(`Failed to runDailyPullExecutionCheck: ${error.message}`);
   }
 }
 
@@ -129,5 +126,5 @@ module.exports = {
   scheduleCreateContactsFromMembersTask,
   scheduleFixPrimaryAddressForMembersTask,
   scheduleFixUrlsWithSpacesTask,
-  scheduleDailyPullExecutionCheckTask,
+  runDailyPullExecutionCheck,
 };

--- a/backend/jobs.js
+++ b/backend/jobs.js
@@ -96,6 +96,20 @@ async function scheduleFixUrlsWithSpacesTask() {
   }
 }
 
+async function scheduleDailyPullExecutionCheckTask() {
+  try {
+    console.log('scheduleDailyPullExecutionCheck started!');
+    return await taskManager().schedule({
+      name: TASKS_NAMES.scheduleDailyPullExecutionCheck,
+      data: {},
+      type: 'scheduled',
+    });
+  } catch (error) {
+    console.error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
+    throw new Error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
+  }
+}
+
 async function updateSiteMapS3() {
   try {
     return await taskManager().schedule({
@@ -115,4 +129,5 @@ module.exports = {
   scheduleCreateContactsFromMembersTask,
   scheduleFixPrimaryAddressForMembersTask,
   scheduleFixUrlsWithSpacesTask,
+  scheduleDailyPullExecutionCheckTask,
 };

--- a/backend/tasks/consts.js
+++ b/backend/tasks/consts.js
@@ -22,6 +22,8 @@ const TASKS_NAMES = {
   fixPrimaryAddressChunk: 'fixPrimaryAddressChunk',
   scheduleFixUrlsWithSpaces: 'scheduleFixUrlsWithSpaces',
   fixUrlsWithSpacesChunk: 'fixUrlsWithSpacesChunk',
+  scheduleDailyPullExecutionCheck: 'scheduleDailyPullExecutionCheck',
+  dailyPullExecutionCheck: 'dailyPullExecutionCheck',
 };
 
 module.exports = {

--- a/backend/tasks/consts.js
+++ b/backend/tasks/consts.js
@@ -22,7 +22,6 @@ const TASKS_NAMES = {
   fixPrimaryAddressChunk: 'fixPrimaryAddressChunk',
   scheduleFixUrlsWithSpaces: 'scheduleFixUrlsWithSpaces',
   fixUrlsWithSpacesChunk: 'fixUrlsWithSpacesChunk',
-  scheduleDailyPullExecutionCheck: 'scheduleDailyPullExecutionCheck',
   dailyPullExecutionCheck: 'dailyPullExecutionCheck',
 };
 

--- a/backend/tasks/daily-pull-backup-check-methods.js
+++ b/backend/tasks/daily-pull-backup-check-methods.js
@@ -1,0 +1,106 @@
+const { taskManager } = require('psdev-task-manager');
+const { COLLECTIONS } = require('psdev-task-manager/public/consts');
+
+const { MEMBER_ACTIONS } = require('../daily-pull/consts');
+const { wixData } = require('../elevated-modules');
+const { queryAllItems } = require('../utils');
+
+const { TASKS_NAMES } = require('./consts');
+
+const DEFAULT_HOURS_BACK = 4;
+
+const getActionsToCheck = includeNone =>
+  includeNone
+    ? Object.values(MEMBER_ACTIONS)
+    : Object.values(MEMBER_ACTIONS).filter(action => action !== MEMBER_ACTIONS.NONE);
+
+/**
+ * Schedules an execution check for daily pull status.
+ */
+async function scheduleDailyPullExecutionCheck() {
+  try {
+    console.log('scheduleDailyPullExecutionCheck started!');
+    return await taskManager().schedule({
+      name: TASKS_NAMES.dailyPullExecutionCheck,
+      data: { hoursBack: DEFAULT_HOURS_BACK, includeNone: false },
+      type: 'scheduled',
+    });
+  } catch (error) {
+    console.error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
+    throw new Error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
+  }
+}
+
+/**
+ * Verifies ScheduleMembersDataPerAction tasks exist and succeeded per action.
+ */
+async function dailyPullExecutionCheck(taskData) {
+  const hoursBack =
+    taskData?.hoursBack && Number.isFinite(taskData.hoursBack)
+      ? taskData.hoursBack
+      : DEFAULT_HOURS_BACK;
+  const includeNone = Boolean(taskData?.includeNone);
+  const sinceDate = new Date(Date.now() - hoursBack * 60 * 60 * 1000);
+
+  console.log('dailyPullExecutionCheck started', { hoursBack, sinceDate });
+
+  const tasksQuery = wixData
+    .query(COLLECTIONS.TASKS)
+    .eq('name', TASKS_NAMES.ScheduleMembersDataPerAction)
+    .ge('_createdDate', sinceDate)
+    .limit(1000);
+
+  const tasks = await queryAllItems(tasksQuery);
+  const actionsToCheck = getActionsToCheck(includeNone);
+
+  const statusByAction = actionsToCheck.reduce((acc, action) => {
+    acc[action] = { success: 0, failed: 0, pending: 0, in_progress: 0, skipped: 0 };
+    return acc;
+  }, {});
+
+  tasks.forEach(task => {
+    const action = task?.data?.action;
+    if (!action || !(action in statusByAction)) {
+      return;
+    }
+    const status = task?.status || 'unknown';
+    if (!statusByAction[action][status]) {
+      statusByAction[action][status] = 0;
+    }
+    statusByAction[action][status] += 1;
+  });
+
+  const missingActions = actionsToCheck.filter(
+    action => (statusByAction[action]?.success || 0) === 0
+  );
+
+  const result = {
+    success: missingActions.length === 0,
+    sinceDate: sinceDate.toISOString(),
+    actionsChecked: actionsToCheck,
+    missingActions,
+    statusByAction,
+    totalTasksFound: tasks.length,
+  };
+
+  if (missingActions.length > 0) {
+    console.log('Missing daily pull actions detected, scheduling fallback daily pull run', {
+      missingActions,
+    });
+    await taskManager().schedule({
+      name: TASKS_NAMES.ScheduleDailyMembersDataSync,
+      data: {},
+      type: 'scheduled',
+    });
+    result.fallbackScheduled = true;
+  }
+
+  console.log('dailyPullExecutionCheck result', JSON.stringify(result, null, 2));
+
+  return result;
+}
+
+module.exports = {
+  scheduleDailyPullExecutionCheck,
+  dailyPullExecutionCheck,
+};

--- a/backend/tasks/daily-pull-check-methods.js
+++ b/backend/tasks/daily-pull-check-methods.js
@@ -24,8 +24,7 @@ async function dailyPullExecutionCheck(taskData) {
   const rootTasksQuery = wixData
     .query(COLLECTIONS.TASKS)
     .eq('name', TASKS_NAMES.ScheduleDailyMembersDataSync)
-    .ge('_createdDate', sinceDate)
-    .limit(1000);
+    .ge('_createdDate', sinceDate);
 
   const rootTasks = await queryAllItems(rootTasksQuery);
   const rootTaskScheduled = rootTasks.length > 0;

--- a/backend/tasks/daily-pull-check-methods.js
+++ b/backend/tasks/daily-pull-check-methods.js
@@ -1,7 +1,6 @@
 const { taskManager } = require('psdev-task-manager');
 const { COLLECTIONS } = require('psdev-task-manager/public/consts');
 
-const { MEMBER_ACTIONS } = require('../daily-pull/consts');
 const { wixData } = require('../elevated-modules');
 const { queryAllItems } = require('../utils');
 
@@ -9,66 +8,38 @@ const { TASKS_NAMES } = require('./consts');
 
 const DEFAULT_HOURS_BACK = 4;
 
-const getActionsToCheck = includeNone =>
-  includeNone
-    ? Object.values(MEMBER_ACTIONS)
-    : Object.values(MEMBER_ACTIONS).filter(action => action !== MEMBER_ACTIONS.NONE);
-
 /**
- * Verifies ScheduleMembersDataPerAction tasks exist and succeeded per action.
+ * Detects whether the daily pull was scheduled (cron / root task).
+ * If no `ScheduleDailyMembersDataSync` task exists in the lookback window, schedules it.
  */
 async function dailyPullExecutionCheck(taskData) {
   const hoursBack =
     taskData?.hoursBack && Number.isFinite(taskData.hoursBack)
       ? taskData.hoursBack
       : DEFAULT_HOURS_BACK;
-  const includeNone = Boolean(taskData?.includeNone);
   const sinceDate = new Date(Date.now() - hoursBack * 60 * 60 * 1000);
 
   console.log('dailyPullExecutionCheck started', { hoursBack, sinceDate });
 
-  const tasksQuery = wixData
+  const rootTasksQuery = wixData
     .query(COLLECTIONS.TASKS)
-    .eq('name', TASKS_NAMES.ScheduleMembersDataPerAction)
+    .eq('name', TASKS_NAMES.ScheduleDailyMembersDataSync)
     .ge('_createdDate', sinceDate)
     .limit(1000);
 
-  const tasks = await queryAllItems(tasksQuery);
-  const actionsToCheck = getActionsToCheck(includeNone);
-
-  const statusByAction = actionsToCheck.reduce((acc, action) => {
-    acc[action] = { success: 0, failed: 0, pending: 0, in_progress: 0, skipped: 0 };
-    return acc;
-  }, {});
-
-  tasks.forEach(task => {
-    const action = task?.data?.action;
-    if (!action || !(action in statusByAction)) {
-      return;
-    }
-    const status = task?.status || 'unknown';
-    if (!statusByAction[action][status]) {
-      statusByAction[action][status] = 0;
-    }
-    statusByAction[action][status] += 1;
-  });
-
-  const missingActions = actionsToCheck.filter(
-    action => (statusByAction[action]?.success || 0) === 0
-  );
+  const rootTasks = await queryAllItems(rootTasksQuery);
+  const rootTaskScheduled = rootTasks.length > 0;
 
   const result = {
-    success: missingActions.length === 0,
+    success: rootTaskScheduled,
     sinceDate: sinceDate.toISOString(),
-    actionsChecked: actionsToCheck,
-    missingActions,
-    statusByAction,
-    totalTasksFound: tasks.length,
+    rootTaskName: TASKS_NAMES.ScheduleDailyMembersDataSync,
+    rootTasksFound: rootTasks.length,
   };
 
-  if (missingActions.length > 0) {
-    console.log('Missing daily pull actions detected, scheduling fallback daily pull run', {
-      missingActions,
+  if (!rootTaskScheduled) {
+    console.log('ScheduleDailyMembersDataSync missing in window; scheduling root daily pull', {
+      hoursBack,
     });
     await taskManager().schedule({
       name: TASKS_NAMES.ScheduleDailyMembersDataSync,

--- a/backend/tasks/daily-pull-check-methods.js
+++ b/backend/tasks/daily-pull-check-methods.js
@@ -15,23 +15,6 @@ const getActionsToCheck = includeNone =>
     : Object.values(MEMBER_ACTIONS).filter(action => action !== MEMBER_ACTIONS.NONE);
 
 /**
- * Schedules an execution check for daily pull status.
- */
-async function scheduleDailyPullExecutionCheck() {
-  try {
-    console.log('scheduleDailyPullExecutionCheck started!');
-    return await taskManager().schedule({
-      name: TASKS_NAMES.dailyPullExecutionCheck,
-      data: { hoursBack: DEFAULT_HOURS_BACK, includeNone: false },
-      type: 'scheduled',
-    });
-  } catch (error) {
-    console.error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
-    throw new Error(`Failed to scheduleDailyPullExecutionCheck: ${error.message}`);
-  }
-}
-
-/**
  * Verifies ScheduleMembersDataPerAction tasks exist and succeeded per action.
  */
 async function dailyPullExecutionCheck(taskData) {
@@ -101,6 +84,5 @@ async function dailyPullExecutionCheck(taskData) {
 }
 
 module.exports = {
-  scheduleDailyPullExecutionCheck,
   dailyPullExecutionCheck,
 };

--- a/backend/tasks/index.js
+++ b/backend/tasks/index.js
@@ -6,4 +6,5 @@ module.exports = {
   ...require('./url-migration-methods'),
   ...require('./address-primary-methods'),
   ...require('./url-space-fix-methods'),
+  ...require('./daily-pull-backup-check-methods'),
 };

--- a/backend/tasks/index.js
+++ b/backend/tasks/index.js
@@ -6,5 +6,5 @@ module.exports = {
   ...require('./url-migration-methods'),
   ...require('./address-primary-methods'),
   ...require('./url-space-fix-methods'),
-  ...require('./daily-pull-backup-check-methods'),
+  ...require('./daily-pull-check-methods'),
 };

--- a/backend/tasks/tasks-configs.js
+++ b/backend/tasks/tasks-configs.js
@@ -9,10 +9,7 @@ const {
   fixPrimaryAddressChunk,
 } = require('./address-primary-methods');
 const { TASKS_NAMES } = require('./consts');
-const {
-  scheduleDailyPullExecutionCheck,
-  dailyPullExecutionCheck,
-} = require('./daily-pull-backup-check-methods');
+const { dailyPullExecutionCheck } = require('./daily-pull-check-methods');
 const {
   scheduleTaskForEmptyAboutYouMembers,
   convertAboutYouHtmlToRichContent,
@@ -205,13 +202,6 @@ const TASKS = {
     process: fixUrlsWithSpacesChunk,
     shouldSkipCheck: () => false,
     estimatedDurationSec: 80,
-  },
-  [TASKS_NAMES.scheduleDailyPullExecutionCheck]: {
-    name: TASKS_NAMES.scheduleDailyPullExecutionCheck,
-    getIdentifier: () => 'SHOULD_NEVER_SKIP',
-    process: scheduleDailyPullExecutionCheck,
-    shouldSkipCheck: () => false,
-    estimatedDurationSec: 30,
   },
   [TASKS_NAMES.dailyPullExecutionCheck]: {
     name: TASKS_NAMES.dailyPullExecutionCheck,

--- a/backend/tasks/tasks-configs.js
+++ b/backend/tasks/tasks-configs.js
@@ -10,6 +10,10 @@ const {
 } = require('./address-primary-methods');
 const { TASKS_NAMES } = require('./consts');
 const {
+  scheduleDailyPullExecutionCheck,
+  dailyPullExecutionCheck,
+} = require('./daily-pull-backup-check-methods');
+const {
   scheduleTaskForEmptyAboutYouMembers,
   convertAboutYouHtmlToRichContent,
   compileFiltersOptions,
@@ -201,6 +205,20 @@ const TASKS = {
     process: fixUrlsWithSpacesChunk,
     shouldSkipCheck: () => false,
     estimatedDurationSec: 80,
+  },
+  [TASKS_NAMES.scheduleDailyPullExecutionCheck]: {
+    name: TASKS_NAMES.scheduleDailyPullExecutionCheck,
+    getIdentifier: () => 'SHOULD_NEVER_SKIP',
+    process: scheduleDailyPullExecutionCheck,
+    shouldSkipCheck: () => false,
+    estimatedDurationSec: 30,
+  },
+  [TASKS_NAMES.dailyPullExecutionCheck]: {
+    name: TASKS_NAMES.dailyPullExecutionCheck,
+    getIdentifier: task => task.data,
+    process: dailyPullExecutionCheck,
+    shouldSkipCheck: () => false,
+    estimatedDurationSec: 30,
   },
 };
 


### PR DESCRIPTION
## Summary
- Add a daily pull execution check that verifies per‑action task success.
- Trigger a fallback daily pull schedule when any action is missing.

## Test plan
- Run `runDailyPullExecutionCheck` and confirm it reports missing actions and schedules fallback.
- Verify it reports success when all actions have a success status.