### PR TITLE
Fix homepage geolocation blocking load for 30+ seconds

### DIFF
--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -5,6 +5,23 @@ const { DEFAULT_FILTER } = require('../consts.js');
 
 const { debouncedFunction } = require('./sharedUtils.js');
 
+function isValidGeolocation(lat, lng) {
+  return Number.isFinite(lat) && Number.isFinite(lng) && (lat !== 0 || lng !== 0);
+}
+
+function applyGeolocationToFilter(filter, lat, lng, isSearchingNearby) {
+  return {
+    ...filter,
+    postalcode: isSearchingNearby ? null : filter.postalcode,
+    state: isSearchingNearby ? [] : filter.state,
+    city: isSearchingNearby ? [] : filter.city,
+    stateSearch: isSearchingNearby ? '' : filter.stateSearch,
+    citySearch: isSearchingNearby ? '' : filter.citySearch,
+    latitude: lat,
+    longitude: lng,
+  };
+}
+
 const createHomepageUtils = (_$w, filterProfiles) => {
   const getFiltersSelectors = filterName => ({
     checkBoxContainerSelector: _$w(`#${filterName}CheckBoxContainer`),
@@ -362,29 +379,24 @@ const createHomepageUtils = (_$w, filterProfiles) => {
       });
   }
   async function getAndSetUserLocation(isSearchingNearby, filter) {
-    try {
-      let location = {
-        coords: {
-          latitude: 0,
-          longitude: 0,
-        },
+    const { latitude: existingLat, longitude: existingLng } = filter;
+    if (isValidGeolocation(existingLat, existingLng)) {
+      return {
+        success: true,
+        filter: applyGeolocationToFilter(filter, existingLat, existingLng, isSearchingNearby),
       };
-      location = await wixWindow.getCurrentGeolocation();
+    }
+
+    try {
+      const location = await wixWindow.getCurrentGeolocation();
 
       console.log('location inside getAndSetUserLocation', location);
       const userLat = location.coords?.latitude ?? 0;
       const userLong = location.coords?.longitude ?? 0;
-      filter = {
-        ...filter,
-        postalcode: isSearchingNearby ? null : filter.postalcode,
-        state: isSearchingNearby ? [] : filter.state,
-        city: isSearchingNearby ? [] : filter.city,
-        stateSearch: isSearchingNearby ? '' : filter.stateSearch,
-        citySearch: isSearchingNearby ? '' : filter.citySearch,
-        latitude: userLat,
-        longitude: userLong,
+      return {
+        success: true,
+        filter: applyGeolocationToFilter(filter, userLat, userLong, isSearchingNearby),
       };
-      return { success: true, filter };
     } catch (error) {
       console.warn('Failed to get user location in getAndSetUserLocation', error);
       return { success: false, filter };

--- a/public/Utils/homePage.js
+++ b/public/Utils/homePage.js
@@ -22,6 +22,26 @@ function applyGeolocationToFilter(filter, lat, lng, isSearchingNearby) {
   };
 }
 
+const GEOLOCATION_TIMEOUT_MS = 10000;
+
+function getCurrentGeolocationWithTimeout(timeoutMs = GEOLOCATION_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`Geolocation timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    wixWindow
+      .getCurrentGeolocation()
+      .then(location => {
+        clearTimeout(timer);
+        resolve(location);
+      })
+      .catch(error => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
 const createHomepageUtils = (_$w, filterProfiles) => {
   const getFiltersSelectors = filterName => ({
     checkBoxContainerSelector: _$w(`#${filterName}CheckBoxContainer`),
@@ -388,7 +408,7 @@ const createHomepageUtils = (_$w, filterProfiles) => {
     }
 
     try {
-      const location = await wixWindow.getCurrentGeolocation();
+      const location = await getCurrentGeolocationWithTimeout();
 
       console.log('location inside getAndSetUserLocation', location);
       const userLat = location.coords?.latitude ?? 0;


### PR DESCRIPTION
## Summary

Fixes a homepage load regression where nearby search could block the UI for **35+ seconds** due to redundant and unbounded geolocation calls.

Production logs from a user session on **New Fast Homepage** (`loadId: hpl_1778626373842_286t5ony_5ujxvff8`, test-ascpmembers.com) showed:

| Phase | Duration |
|-------|----------|
| First `getCurrentGeolocation` (URL params / `parseAndValidateQueryParams`) | ~1.5s |
| `fetchFilterData` | ~30ms |
| **Second** `getCurrentGeolocation` (`nearByHandler` on default nearby path) | **~31s** |
| `filterProfiles` nearby search | ~2.7s |
| **Total to `after_handleUrlParams`** | **~35.5s** |

The second call returned the **same coordinates** as the first (~39.7, -105.28) but still blocked `Promise.all([fetchFilterData(), nearByHandler()])` before search could run.

## Root cause

On the default nearby path (`isDefaultStateParams` + `nearby=true`):

1. `parseAndValidateQueryParams` calls `getAndSetUserLocation` and stores lat/lng on `filter`.
2. `applyFilterToUI` runs `nearByHandler`, which calls `getAndSetUserLocation` **again** before `updateResults` / `filterProfiles`.

Browsers can throttle or delay back-to-back `wixWindow.getCurrentGeolocation()` requests (permission UI, GPS fix, background tab), leaving the page in **loading state** with no fallback.

## Changes

### Commit 1 — Skip duplicate geolocation when coordinates already exist

- If `filter.latitude` / `filter.longitude` are already valid, reuse them and apply nearby filter field updates without calling the browser API again.
- Extracts `isValidGeolocation` and `applyGeolocationToFilter` helpers to keep behavior consistent between fresh and cached paths.

**Expected impact:** Removes the ~31s duplicate call on the path observed in production logs; nearby search should start shortly after the first geolocation (~1.5s + backend search time).

### Commit 2 — 10s geolocation timeout

- Wraps `getCurrentGeolocation` in `getCurrentGeolocationWithTimeout` (10s default).
- On timeout or error, existing `{ success: false }` handling runs (e.g. `nearByState` UI, nearby checkbox cleared).

**Expected impact:** Caps worst-case wait on the **first** geolocation call instead of hanging 30+ seconds with no user feedback.

## Out of scope

- `filterProfiles` took ~2.7s in the same session — worth a separate backend/perf pass, but not addressed here.

## Test plan

- [ ] Load homepage with `?nearby=true` (default nearby path): confirm only **one** browser geolocation prompt/activity; results appear in a few seconds, not 30+.
- [ ] Fresh load with no query params: first visit still geolocates once; auto-nearby URL flow unchanged.
- [ ] Deny geolocation or simulate slow GPS (>10s): page falls back within ~10s (nearby error state), not indefinite loading.
- [ ] Toggle nearby off/on after a successful search: location still updates when filter has no valid coords.
- [ ] Non-nearby search with state/city/zip params: no regression in filter application.


Made with [Cursor](https://cursor.com)