### PR TITLE
Fix intermittent daily-pull page failures: bulk member lookup + transient-error retry

### DIFF
--- a/backend/__tests__/transient-retry-and-bulk-lookup.test.js
+++ b/backend/__tests__/transient-retry-and-bulk-lookup.test.js
@@ -1,0 +1,129 @@
+jest.mock('../elevated-modules', () => ({
+  wixData: { query: jest.fn() },
+}));
+
+const { wixData } = require('../elevated-modules');
+const { findMembersByIds } = require('../members-data-methods');
+const { withTransientErrorRetry, isTransientNetworkError } = require('../utils');
+
+const makeQueryResult = items => ({ items, hasNext: () => false });
+
+const mockQueryReturning = find => {
+  const query = {
+    hasSome: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    find,
+  };
+  wixData.query.mockReturnValue(query);
+  return query;
+};
+
+describe('isTransientNetworkError', () => {
+  test('matches undici "fetch failed" and common network error codes', () => {
+    expect(isTransientNetworkError(new Error('fetch failed'))).toBe(true);
+    expect(isTransientNetworkError({ message: 'request failed', code: 'ECONNRESET' })).toBe(true);
+    expect(
+      isTransientNetworkError({ message: 'fetch failed', cause: { code: 'UND_ERR_SOCKET' } })
+    ).toBe(true);
+  });
+
+  test('does not match application errors', () => {
+    expect(isTransientNetworkError(new Error('Multiple members found with memberId 1'))).toBe(
+      false
+    );
+    expect(isTransientNetworkError(new Error('WDE0025: validation failed'))).toBe(false);
+  });
+});
+
+describe('withTransientErrorRetry', () => {
+  test('retries transient failures and resolves with the eventual result', async () => {
+    const operation = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValueOnce('ok');
+
+    await expect(withTransientErrorRetry(operation, { baseDelayMs: 1 })).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  test('rethrows immediately on non-transient errors', async () => {
+    const operation = jest.fn().mockRejectedValue(new Error('validation failed'));
+
+    await expect(withTransientErrorRetry(operation, { baseDelayMs: 1 })).rejects.toThrow(
+      'validation failed'
+    );
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  test('gives up after the configured number of retries', async () => {
+    const operation = jest.fn().mockRejectedValue(new Error('fetch failed'));
+
+    await expect(
+      withTransientErrorRetry(operation, { retries: 2, baseDelayMs: 1 })
+    ).rejects.toThrow('fetch failed');
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('findMembersByIds', () => {
+  beforeEach(() => {
+    wixData.query.mockReset();
+  });
+
+  test('returns a map of String(memberId) to member record', async () => {
+    mockQueryReturning(
+      jest.fn().mockResolvedValue(
+        makeQueryResult([
+          { _id: 'a', memberId: 1 },
+          { _id: 'b', memberId: 2 },
+        ])
+      )
+    );
+
+    const membersById = await findMembersByIds([1, 2, 3]);
+
+    expect(membersById.get('1')).toEqual({ _id: 'a', memberId: 1 });
+    expect(membersById.get('2')).toEqual({ _id: 'b', memberId: 2 });
+    expect(membersById.has('3')).toBe(false);
+  });
+
+  test('deduplicates input IDs and skips null/undefined before querying', async () => {
+    const query = mockQueryReturning(jest.fn().mockResolvedValue(makeQueryResult([])));
+
+    await findMembersByIds([1, 1, null, undefined, 2]);
+
+    expect(query.hasSome).toHaveBeenCalledWith('memberId', [1, 2]);
+  });
+
+  test('returns an empty map without querying when there are no IDs', async () => {
+    const membersById = await findMembersByIds([]);
+
+    expect(membersById.size).toBe(0);
+    expect(wixData.query).not.toHaveBeenCalled();
+  });
+
+  test('chunks large ID lists into multiple queries', async () => {
+    const query = mockQueryReturning(jest.fn().mockResolvedValue(makeQueryResult([])));
+    const ids = Array.from({ length: 250 }, (_, i) => i + 1);
+
+    await findMembersByIds(ids);
+
+    expect(query.hasSome).toHaveBeenCalledTimes(3);
+    expect(query.hasSome.mock.calls.map(call => call[1].length)).toEqual([100, 100, 50]);
+  });
+
+  test('throws when multiple records share the same memberId', async () => {
+    mockQueryReturning(
+      jest.fn().mockResolvedValue(
+        makeQueryResult([
+          { _id: 'a', memberId: 1 },
+          { _id: 'b', memberId: 1 },
+        ])
+      )
+    );
+
+    await expect(findMembersByIds([1])).rejects.toThrow(
+      'Multiple members found with memberId(s): [1]'
+    );
+  });
+});

--- a/backend/daily-pull/bulk-process-methods.js
+++ b/backend/daily-pull/bulk-process-methods.js
@@ -1,4 +1,4 @@
-const { bulkSaveMembers, getMemberBySlug } = require('../members-data-methods');
+const { bulkSaveMembers, getMemberBySlug, findMembersByIds } = require('../members-data-methods');
 const { extractUrlCounter } = require('../utils');
 
 const { generateUpdatedMemberData } = require('./process-member-methods');
@@ -132,10 +132,18 @@ const bulkProcessAndSaveMemberData = async ({ memberDataList, currentPageNumber 
   const startTime = Date.now();
 
   try {
+    // Prefetch all existing members for this page in a few chunked queries instead of
+    // one query per member — thousands of parallel lookups made the whole page fail
+    // whenever a single one hit a transient network error.
+    const existingMembersById = await findMembersByIds(
+      memberDataList.map(memberData => memberData?.memberid)
+    );
+
     const processedMemberDataPromises = memberDataList.map(memberData =>
       generateUpdatedMemberData({
         inputMemberData: memberData,
         currentPageNumber,
+        existingDbMember: existingMembersById.get(String(memberData?.memberid)) ?? null,
       })
     );
 

--- a/backend/daily-pull/process-member-methods.js
+++ b/backend/daily-pull/process-member-methods.js
@@ -58,16 +58,26 @@ const ensureUniqueUrl = async ({ url, memberId, fullName }) => {
  * @param {Object} options - The options object
  * @param {Object} options.inputMemberData - Raw member data from API
  * @param {number} options.currentPageNumber - Current page number being processed
+ * @param {Object|null} [options.existingDbMember] - Prefetched DB member (null if none exists).
+ *   Pass it when processing members in bulk to avoid one DB query per member; when omitted,
+ *   the member is looked up individually.
  * @returns {Promise<Object|null>} - Complete updated member data or null if validation fails
  */
-async function generateUpdatedMemberData({ inputMemberData, currentPageNumber }) {
+async function generateUpdatedMemberData({
+  inputMemberData,
+  currentPageNumber,
+  existingDbMember: prefetchedDbMember,
+}) {
   if (!validateCoreMemberData(inputMemberData)) {
     throw new Error(
       'Invalid member data: memberid, email (valid string), and memberships (array) are required'
     );
   }
 
-  const existingDbMember = await findMemberById(inputMemberData.memberid);
+  const existingDbMember =
+    prefetchedDbMember === undefined
+      ? await findMemberById(inputMemberData.memberid)
+      : prefetchedDbMember;
 
   const updatedMemberData = await createCoreMemberData(
     inputMemberData,

--- a/backend/members-data-methods.js
+++ b/backend/members-data-methods.js
@@ -15,6 +15,7 @@ const {
   generateGeoHash,
   searchAllItems,
   runIf,
+  withTransientErrorRetry,
 } = require('./utils');
 
 /**
@@ -158,11 +159,9 @@ async function findMemberById(memberId) {
   }
 
   try {
-    const queryResult = await wixData
-      .query(COLLECTIONS.MEMBERS_DATA)
-      .eq('memberId', memberId)
-      .limit(2)
-      .find();
+    const queryResult = await withTransientErrorRetry(() =>
+      wixData.query(COLLECTIONS.MEMBERS_DATA).eq('memberId', memberId).limit(2).find()
+    );
     if (queryResult.items.length > 1) {
       throw new Error(
         `Multiple members found with memberId ${memberId} members _ids are : [${queryResult.items.map(member => member._id).join(', ')}]`
@@ -171,6 +170,51 @@ async function findMemberById(memberId) {
     return queryResult.items.length === 1 ? queryResult.items[0] : null;
   } catch (error) {
     console.error('Error finding member by ID:', error);
+    throw new Error(`Failed to retrieve member data: ${error.message}`);
+  }
+}
+
+/**
+ * Retrieves existing members for a list of member IDs in bulk.
+ * Uses chunked `hasSome` queries so a full page of members costs a handful of
+ * requests instead of one query per member (the per-member fan-out made a whole
+ * page fail whenever a single query hit a transient "fetch failed").
+ * @param {Array<string|number>} memberIds - Member IDs to look up
+ * @returns {Promise<Map<string, Object>>} - Map of String(memberId) to member record (missing IDs are absent)
+ */
+async function findMembersByIds(memberIds) {
+  const uniqueIds = [...new Set((memberIds || []).filter(id => id !== undefined && id !== null))];
+  const membersById = new Map();
+  if (uniqueIds.length === 0) {
+    return membersById;
+  }
+
+  try {
+    const idChunks = chunkArray(uniqueIds, 100);
+    const chunkResults = await Promise.all(
+      idChunks.map(idsChunk =>
+        withTransientErrorRetry(() =>
+          queryAllItems(
+            wixData.query(COLLECTIONS.MEMBERS_DATA).hasSome('memberId', idsChunk).limit(1000)
+          )
+        )
+      )
+    );
+
+    const duplicateIds = new Set();
+    chunkResults.flat().forEach(member => {
+      const key = String(member.memberId);
+      if (membersById.has(key)) {
+        duplicateIds.add(key);
+      }
+      membersById.set(key, member);
+    });
+    if (duplicateIds.size > 0) {
+      throw new Error(`Multiple members found with memberId(s): [${[...duplicateIds].join(', ')}]`);
+    }
+    return membersById;
+  } catch (error) {
+    console.error('Error finding members by IDs:', error);
     throw new Error(`Failed to retrieve member data: ${error.message}`);
   }
 }
@@ -723,6 +767,7 @@ module.exports = {
   saveRegistrationData,
   bulkSaveMembers,
   findMemberById,
+  findMembersByIds,
   getMemberBySlug,
   getCMSMemberByWixMemberId,
   getAllEmptyAboutYouMembers,

--- a/backend/utils.js
+++ b/backend/utils.js
@@ -210,6 +210,46 @@ function formatDateOnly(dateStr) {
 
 const runIf = (condition, asyncFn) => (condition ? asyncFn() : Promise.resolve(null));
 
+/**
+ * Whether an error looks like a transient network failure that is safe to retry,
+ * e.g. undici's generic "fetch failed" thrown by the Wix SDKs, connection resets
+ * or DNS hiccups under heavy load.
+ * @param {Error} error
+ * @returns {boolean}
+ */
+const isTransientNetworkError = error => {
+  const message = `${error?.message || ''} ${error?.cause?.message || ''} ${error?.code || ''} ${error?.cause?.code || ''}`;
+  return /fetch failed|ECONNRESET|ETIMEDOUT|ECONNREFUSED|EAI_AGAIN|EPIPE|UND_ERR|socket hang up|network error/i.test(
+    message
+  );
+};
+
+/**
+ * Runs an async operation, retrying with exponential backoff when it fails with a
+ * transient network error. Non-transient errors are rethrown immediately.
+ * @param {Function} operation - Async function to run
+ * @param {Object} [options]
+ * @param {number} [options.retries=2] - Maximum number of retries after the first attempt
+ * @param {number} [options.baseDelayMs=500] - Delay before the first retry, doubled each retry
+ * @returns {Promise<any>} - The operation's resolved value
+ */
+const withTransientErrorRetry = async (operation, { retries = 2, baseDelayMs = 500 } = {}) => {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= retries || !isTransientNetworkError(error)) {
+        throw error;
+      }
+      const delayMs = baseDelayMs * 2 ** attempt;
+      console.warn(
+        `Transient network error (attempt ${attempt + 1}/${retries + 1}): ${error.message}. Retrying in ${delayMs}ms`
+      );
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+};
+
 module.exports = {
   getSiteConfigs,
   retrieveAllItems,
@@ -232,4 +272,6 @@ module.exports = {
   isPAC_STAFF,
   searchAllItems,
   runIf,
+  isTransientNetworkError,
+  withTransientErrorRetry,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "axios": "^1.13.1",
         "crypto": "^1.0.1",
         "csv-parser": "^3.0.0",
+        "debug": "^4.4.3",
         "jwt-js-decode": "^1.9.0",
         "lodash": "^4.17.21",
         "ngeohash": "^0.6.3",
@@ -5921,7 +5922,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -9599,7 +9599,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "axios": "^1.13.1",
     "crypto": "^1.0.1",
     "csv-parser": "^3.0.0",
+    "debug": "^4.4.3",
     "jwt-js-decode": "^1.9.0",
     "lodash": "^4.17.21",
     "ngeohash": "^0.6.3",


### PR DESCRIPTION
## Problem

During full syncs (`action: none`, `includeNone: true`), several `SyncMembers` page tasks fail per run with:

```
[processTask] for SyncMembers Task failed with error: Error: Page N synchronization failed: Bulk operation failed: Failed to retrieve member data: fetch failed
```

The `fetch failed` is **not** from the axios migration (#112) — axios doesn't use `fetch`. It's the native undici fetch inside the `@wix/data` SDK, thrown by `findMemberById`.

The root cause is fan-out: `bulkProcessAndSaveMemberData` ran `generateUpdatedMemberData` for every member of a page in parallel, and each call did its own `wixData.query` — up to ~2,500 concurrent queries per page, across ~20+ concurrent page tasks. At that volume an occasional transient socket failure is statistically guaranteed, and because the lookups ran under a fail-fast `Promise.all`, **one blip failed the entire 2,500-member page**. That's why some pages succeed and others fail at random.

## Fix

- **Bulk prefetch:** new `findMembersByIds` in `members-data-methods.js` fetches all existing members of a page with chunked `hasSome` queries (~25 requests instead of ~2,500) and `bulkProcessAndSaveMemberData` passes the prefetched record into `generateUpdatedMemberData`. Duplicate-`memberId` detection is preserved (still throws, same as `findMemberById`).
- **Retry on transient errors:** new `withTransientErrorRetry` util retries `fetch failed` / `ECONNRESET` / `ETIMEDOUT`-style failures with exponential backoff (2 retries). Applied to `findMemberById` and the new bulk lookup. Non-transient errors still throw immediately.
- **Silence the startup error:** added `debug` as a direct dependency. `follow-redirects` (axios's transport) optionally requires it, and the strict module resolution in the Wix serverless runtime logged `MODULE_NOT_FOUND ... follow-redirects tried to access debug` at every container start. Harmless, but it was polluting error logs.

`generateUpdatedMemberData` keeps its old behavior (individual lookup) when no prefetched member is passed, so other callers are unaffected.

## Testing

- New test suite `backend/__tests__/transient-retry-and-bulk-lookup.test.js`: retry/give-up/non-transient paths, map keying, input dedup, chunking, duplicate-memberId throw (10 tests)
- `npm test`: 34/34 pass
- `npm run lint` (madge + eslint) and prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)