### PR TITLE
Fix daily pull execution check: daily false alarms + environment-blind fallback (401s on test-ascp)

### DIFF
--- a/backend/__tests__/daily-pull-execution-check.test.js
+++ b/backend/__tests__/daily-pull-execution-check.test.js
@@ -1,0 +1,124 @@
+jest.mock('../elevated-modules', () => ({
+  wixData: { query: jest.fn() },
+}));
+jest.mock('psdev-task-manager', () => ({ taskManager: jest.fn() }));
+
+const { taskManager } = require('psdev-task-manager');
+
+const { buildDailyPullTasks } = require('../daily-pull/schedule-methods');
+const { wixData } = require('../elevated-modules');
+const { TASKS_NAMES } = require('../tasks/consts');
+const { dailyPullExecutionCheck } = require('../tasks/daily-pull-check-methods');
+
+const makeQueryResult = items => ({ items, hasNext: () => false });
+
+const mockTasksQuery = items => {
+  const query = {
+    hasSome: jest.fn().mockReturnThis(),
+    ge: jest.fn().mockReturnThis(),
+    find: jest.fn().mockResolvedValue(makeQueryResult(items)),
+  };
+  wixData.query.mockReturnValue(query);
+  return query;
+};
+
+describe('buildDailyPullTasks', () => {
+  test('schedules one ScheduleMembersDataPerAction task per action, excluding none by default', () => {
+    const tasks = buildDailyPullTasks();
+
+    expect(tasks.map(task => task.data.action).sort()).toEqual(['drop', 'new', 'update']);
+    tasks.forEach(task => {
+      expect(task.name).toBe(TASKS_NAMES.ScheduleMembersDataPerAction);
+      expect(task.type).toBe('scheduled');
+      expect(task.data).toEqual({ action: task.data.action });
+    });
+  });
+
+  test('includes the none action and flag when includeNone is set', () => {
+    const tasks = buildDailyPullTasks({ includeNone: true });
+
+    expect(tasks.map(task => task.data.action).sort()).toEqual(['drop', 'new', 'none', 'update']);
+    tasks.forEach(task => expect(task.data.includeNone).toBe(true));
+  });
+
+  test('propagates isTestEnvironment and backupDate to every task', () => {
+    const tasks = buildDailyPullTasks({ isTestEnvironment: true, backupDate: '2026-06-01' });
+
+    tasks.forEach(task => {
+      expect(task.data.isTestEnvironment).toBe(true);
+      expect(task.data.backupDate).toBe('2026-06-01');
+    });
+  });
+});
+
+describe('dailyPullExecutionCheck', () => {
+  let scheduleInBulk;
+
+  beforeEach(() => {
+    wixData.query.mockReset();
+    scheduleInBulk = jest.fn().mockResolvedValue(undefined);
+    taskManager.mockReturnValue({ scheduleInBulk });
+  });
+
+  test('counts the per-action tasks the cron creates as evidence the pull ran', async () => {
+    const query = mockTasksQuery([{ name: TASKS_NAMES.ScheduleMembersDataPerAction }]);
+
+    const result = await dailyPullExecutionCheck({});
+
+    expect(query.hasSome).toHaveBeenCalledWith('name', [
+      TASKS_NAMES.ScheduleMembersDataPerAction,
+      TASKS_NAMES.ScheduleDailyMembersDataSync,
+    ]);
+    expect(result.success).toBe(true);
+    expect(result.fallbackScheduled).toBeUndefined();
+    expect(scheduleInBulk).not.toHaveBeenCalled();
+  });
+
+  test('schedules the per-action fallback with environment flags when no pull is found', async () => {
+    mockTasksQuery([]);
+
+    const result = await dailyPullExecutionCheck({ isTestEnvironment: true, includeNone: true });
+
+    expect(result.success).toBe(false);
+    expect(result.fallbackScheduled).toBe(true);
+    expect(scheduleInBulk).toHaveBeenCalledTimes(1);
+    const scheduledTasks = scheduleInBulk.mock.calls[0][0];
+    expect(scheduledTasks.map(task => task.data.action).sort()).toEqual([
+      'drop',
+      'new',
+      'none',
+      'update',
+    ]);
+    scheduledTasks.forEach(task => {
+      expect(task.name).toBe(TASKS_NAMES.ScheduleMembersDataPerAction);
+      expect(task.data.isTestEnvironment).toBe(true);
+      expect(task.data.includeNone).toBe(true);
+    });
+  });
+
+  test('fallback defaults to production flags when no task data is provided', async () => {
+    mockTasksQuery([]);
+
+    await dailyPullExecutionCheck(undefined);
+
+    const scheduledTasks = scheduleInBulk.mock.calls[0][0];
+    expect(scheduledTasks.map(task => task.data.action).sort()).toEqual(['drop', 'new', 'update']);
+    scheduledTasks.forEach(task => {
+      expect(task.data.isTestEnvironment).toBeUndefined();
+      expect(task.data.includeNone).toBeUndefined();
+    });
+  });
+
+  test('uses the provided lookback window', async () => {
+    const query = mockTasksQuery([{ name: TASKS_NAMES.ScheduleDailyMembersDataSync }]);
+    const before = Date.now();
+
+    const result = await dailyPullExecutionCheck({ hoursBack: 12 });
+
+    const sinceDate = query.ge.mock.calls[0][1];
+    expect(query.ge).toHaveBeenCalledWith('_createdDate', expect.any(Date));
+    const expectedSince = before - 12 * 60 * 60 * 1000;
+    expect(Math.abs(sinceDate.getTime() - expectedSince)).toBeLessThan(5000);
+    expect(result.success).toBe(true);
+  });
+});

--- a/backend/daily-pull/schedule-methods.js
+++ b/backend/daily-pull/schedule-methods.js
@@ -1,0 +1,41 @@
+const { taskManager } = require('psdev-task-manager');
+
+const { TASKS_NAMES } = require('../tasks/consts');
+
+const { MEMBER_ACTIONS } = require('./consts');
+
+/**
+ * Builds the per-action daily pull tasks. Single source of truth for what a
+ * "daily pull" schedules, shared by the cron job and the execution-check
+ * fallback so both produce identical tasks (same names, same environment flags).
+ * @param {Object} [options]
+ * @param {string} [options.backupDate] - Optional backup date (YYYY-MM-DD) to pull from the backup endpoint
+ * @param {boolean} [options.isTestEnvironment=false] - Whether to pull from the test PAC API
+ * @param {boolean} [options.includeNone=false] - Whether to also sync the NONE action
+ * @returns {Array<Object>} - Task definitions for taskManager().scheduleInBulk
+ */
+const buildDailyPullTasks = ({ backupDate, isTestEnvironment, includeNone } = {}) => {
+  const actionsToSync = includeNone
+    ? Object.values(MEMBER_ACTIONS)
+    : Object.values(MEMBER_ACTIONS).filter(action => action !== MEMBER_ACTIONS.NONE);
+  return actionsToSync.map(action => ({
+    name: TASKS_NAMES.ScheduleMembersDataPerAction,
+    data: {
+      action,
+      ...(backupDate ? { backupDate } : {}),
+      ...(isTestEnvironment ? { isTestEnvironment } : {}),
+      ...(includeNone ? { includeNone } : {}),
+    },
+    type: 'scheduled',
+  }));
+};
+
+/**
+ * Schedules the daily pull (one ScheduleMembersDataPerAction task per action).
+ * @param {Object} [options] - Same options as buildDailyPullTasks
+ * @returns {Promise<any>}
+ */
+const scheduleDailyPullTasks = options =>
+  taskManager().scheduleInBulk(buildDailyPullTasks(options));
+
+module.exports = { buildDailyPullTasks, scheduleDailyPullTasks };

--- a/backend/jobs.js
+++ b/backend/jobs.js
@@ -1,6 +1,6 @@
 const { taskManager } = require('psdev-task-manager');
 
-const { MEMBER_ACTIONS } = require('./daily-pull/consts');
+const { scheduleDailyPullTasks } = require('./daily-pull/schedule-methods');
 const { TASKS_NAMES } = require('./tasks/consts');
 const { dailyPullExecutionCheck } = require('./tasks/daily-pull-check-methods');
 const { TASKS } = require('./tasks/tasks-configs');
@@ -34,21 +34,7 @@ async function scheduleDailyPullTask(options = null) {
     console.log(`isTestEnvironment: ${isTestEnvironment}`);
     console.log(`includeNone: ${includeNone}`);
 
-    const actionsToSync = includeNone
-      ? Object.values(MEMBER_ACTIONS)
-      : Object.values(MEMBER_ACTIONS).filter(action => action !== MEMBER_ACTIONS.NONE);
-    const toScheduleTasks = actionsToSync.map(action => ({
-      name: TASKS_NAMES.ScheduleMembersDataPerAction,
-      data: {
-        action,
-        ...(backupDate ? { backupDate } : {}),
-        ...(isTestEnvironment ? { isTestEnvironment } : {}),
-        ...(includeNone ? { includeNone } : {}),
-      },
-      type: 'scheduled',
-    }));
-
-    return await taskManager().scheduleInBulk(toScheduleTasks);
+    return await scheduleDailyPullTasks({ backupDate, isTestEnvironment, includeNone });
   } catch (error) {
     console.error(`Failed to scheduleDailyPullTask: ${error.message}`);
     throw new Error(`Failed to scheduleDailyPullTask: ${error.message}`);
@@ -111,10 +97,18 @@ async function scheduleNormalizeMemberEmailsTask() {
   }
 }
 
-async function runDailyPullExecutionCheck() {
+/**
+ * Runs the daily pull execution check (watchdog).
+ * @param {Object} [options]
+ * @param {number} [options.hoursBack=4] - Lookback window in hours
+ * @param {boolean} [options.isTestEnvironment=false] - Pull from the test PAC API if the fallback fires
+ * @param {boolean} [options.includeNone=false] - Include the NONE action if the fallback fires
+ * @returns {Promise<Object>} - Check result
+ */
+async function runDailyPullExecutionCheck(options = {}) {
   try {
     console.log('runDailyPullExecutionCheck started!');
-    return await dailyPullExecutionCheck({});
+    return await dailyPullExecutionCheck(options || {});
   } catch (error) {
     console.error(`Failed to runDailyPullExecutionCheck: ${error.message}`);
     throw new Error(`Failed to runDailyPullExecutionCheck: ${error.message}`);

--- a/backend/tasks/daily-pull-check-methods.js
+++ b/backend/tasks/daily-pull-check-methods.js
@@ -1,6 +1,6 @@
-const { taskManager } = require('psdev-task-manager');
 const { COLLECTIONS } = require('psdev-task-manager/public/consts');
 
+const { scheduleDailyPullTasks } = require('../daily-pull/schedule-methods');
 const { wixData } = require('../elevated-modules');
 const { queryAllItems } = require('../utils');
 
@@ -8,43 +8,63 @@ const { TASKS_NAMES } = require('./consts');
 
 const DEFAULT_HOURS_BACK = 4;
 
+// The cron path (scheduleDailyPullTask) creates ScheduleMembersDataPerAction tasks
+// directly; ScheduleDailyMembersDataSync only exists when the pull is triggered via
+// the root task. Either one in the window is evidence the daily pull was scheduled.
+const DAILY_PULL_TASK_NAMES = [
+  TASKS_NAMES.ScheduleMembersDataPerAction,
+  TASKS_NAMES.ScheduleDailyMembersDataSync,
+];
+
 /**
- * Detects whether the daily pull was scheduled (cron / root task).
- * If no `ScheduleDailyMembersDataSync` task exists in the lookback window, schedules it.
+ * Detects whether the daily pull was scheduled in the lookback window.
+ * If no daily pull task exists, re-schedules the same per-action tasks the cron
+ * would have created, propagating the environment flags from the task data so a
+ * test site's fallback pulls from the test PAC API.
+ * @param {Object} [taskData]
+ * @param {number} [taskData.hoursBack=4] - Lookback window in hours
+ * @param {boolean} [taskData.isTestEnvironment=false] - Pull from the test PAC API on fallback
+ * @param {boolean} [taskData.includeNone=false] - Include the NONE action on fallback
+ * @returns {Promise<Object>} - Check result
  */
 async function dailyPullExecutionCheck(taskData) {
   const hoursBack =
     taskData?.hoursBack && Number.isFinite(taskData.hoursBack)
       ? taskData.hoursBack
       : DEFAULT_HOURS_BACK;
+  const isTestEnvironment = Boolean(taskData?.isTestEnvironment);
+  const includeNone = Boolean(taskData?.includeNone);
   const sinceDate = new Date(Date.now() - hoursBack * 60 * 60 * 1000);
 
-  console.log('dailyPullExecutionCheck started', { hoursBack, sinceDate });
+  console.log('dailyPullExecutionCheck started', {
+    hoursBack,
+    sinceDate,
+    isTestEnvironment,
+    includeNone,
+  });
 
-  const rootTasksQuery = wixData
+  const dailyPullTasksQuery = wixData
     .query(COLLECTIONS.TASKS)
-    .eq('name', TASKS_NAMES.ScheduleDailyMembersDataSync)
+    .hasSome('name', DAILY_PULL_TASK_NAMES)
     .ge('_createdDate', sinceDate);
 
-  const rootTasks = await queryAllItems(rootTasksQuery);
-  const rootTaskScheduled = rootTasks.length > 0;
+  const dailyPullTasks = await queryAllItems(dailyPullTasksQuery);
+  const dailyPullScheduled = dailyPullTasks.length > 0;
 
   const result = {
-    success: rootTaskScheduled,
+    success: dailyPullScheduled,
     sinceDate: sinceDate.toISOString(),
-    rootTaskName: TASKS_NAMES.ScheduleDailyMembersDataSync,
-    rootTasksFound: rootTasks.length,
+    checkedTaskNames: DAILY_PULL_TASK_NAMES,
+    dailyPullTasksFound: dailyPullTasks.length,
   };
 
-  if (!rootTaskScheduled) {
-    console.log('ScheduleDailyMembersDataSync missing in window; scheduling root daily pull', {
+  if (!dailyPullScheduled) {
+    console.log('No daily pull tasks found in window; re-scheduling per-action pull tasks', {
       hoursBack,
+      isTestEnvironment,
+      includeNone,
     });
-    await taskManager().schedule({
-      name: TASKS_NAMES.ScheduleDailyMembersDataSync,
-      data: {},
-      type: 'scheduled',
-    });
+    await scheduleDailyPullTasks({ isTestEnvironment, includeNone });
     result.fallbackScheduled = true;
   }
 


### PR DESCRIPTION
## Problem

`runDailyPullExecutionCheck` (the daily-pull watchdog from [#104](https://github.com/psdevteamenterprise/abmp-npm/pull/104), currently enabled only on test-ascp) has two bugs that combine into the daily `[fetchPACMembers] failed with status 401` task failures on the test site:

1. **It always fires a false alarm.** It looks for a root `ScheduleDailyMembersDataSync` task in the lookback window, but the cron path (`scheduleDailyPullTask`) never creates a task by that name — it schedules the `ScheduleMembersDataPerAction` tasks directly. So the check concludes the pull didn't run *every day*, even two hours after a successful sync, and schedules its fallback.

2. **The fallback loses the environment.** It scheduled the root task with `data: {}`; the static `childTasks` config gives children only `{ action }`. On test-ascp the children then call the **production** PAC API with the test site's `members-data-api-key` → 401 for `new`/`update`/`drop`, every day, times retries. (If the key had been valid for prod, this would have silently synced production member data into the test site — the 401 was the lucky outcome.)

## Fix

- **Shared task builder**: new `buildDailyPullTasks` / `scheduleDailyPullTasks` in `backend/daily-pull/schedule-methods.js` — single source of truth for what a daily pull schedules. `scheduleDailyPullTask` (cron) and the watchdog fallback now both use it, so they produce identical tasks.
- **Check looks for the right evidence**: `hasSome('name', [ScheduleMembersDataPerAction, ScheduleDailyMembersDataSync])` — counts both the cron path and root-task-triggered pulls.
- **Fallback propagates environment flags**: `dailyPullExecutionCheck` reads `isTestEnvironment` / `includeNone` from its task data and passes them to the fallback tasks. `runDailyPullExecutionCheck(options)` forwards options, so a test site's `jobs.js` can call it with `{ isTestEnvironment: true, includeNone: true }`.

Note: `psdev-task-manager` already merges parent task data into child tasks (`{ ...restParentData, ...data }`), so the root-task path also propagates flags correctly when the root is scheduled with real data — the old fallback's `data: {}` was the gap.

## Follow-ups after merge + publish

- **test-ascp**: update `src/backend/jobs.js` to call `_runDailyPullExecutionCheck({ isTestEnvironment: true, includeNone: true })`, and bump the package. Until then, the stopgap is removing the `runDailyPullExecutionCheck` job from its `jobs.config`.
- **Prod sites**: safe to enable the watchdog once they're on this version (with default options).

## Testing

- New suite `backend/__tests__/daily-pull-execution-check.test.js` (7 tests): task builder action filtering and flag propagation, evidence detection for both task names, fallback with test/prod flags, lookback window
- `npm test` 31/31, madge cycle check, eslint, prettier all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)