### PR TITLE
Add task to hide all member addresses (set addressStatus to DONT_SHOW)

### DIFF
--- a/backend/jobs.js
+++ b/backend/jobs.js
@@ -98,6 +98,24 @@ async function scheduleNormalizeMemberEmailsTask() {
 }
 
 /**
+ * Schedules hiding ALL addresses for ALL members that have any address (sets each address's
+ * addressStatus to DONT_SHOW). Manually triggered one-off maintenance task.
+ */
+async function scheduleHideAllMemberAddressesTask() {
+  try {
+    console.log('scheduleHideAllMemberAddresses started!');
+    return await taskManager().schedule({
+      name: TASKS_NAMES.scheduleHideAllMemberAddresses,
+      data: {},
+      type: 'scheduled',
+    });
+  } catch (error) {
+    console.error(`Failed to scheduleHideAllMemberAddresses: ${error.message}`);
+    throw new Error(`Failed to scheduleHideAllMemberAddresses: ${error.message}`);
+  }
+}
+
+/**
  * Runs the daily pull execution check (watchdog).
  * @param {Object} [options]
  * @param {number} [options.hoursBack=4] - Lookback window in hours
@@ -135,5 +153,6 @@ module.exports = {
   scheduleFixPrimaryAddressForMembersTask,
   scheduleFixUrlsWithSpacesTask,
   scheduleNormalizeMemberEmailsTask,
+  scheduleHideAllMemberAddressesTask,
   runDailyPullExecutionCheck,
 };

--- a/backend/tasks/consts.js
+++ b/backend/tasks/consts.js
@@ -22,6 +22,8 @@ const TASKS_NAMES = {
   fixPrimaryAddressChunk: 'fixPrimaryAddressChunk',
   scheduleFixUrlsWithSpaces: 'scheduleFixUrlsWithSpaces',
   fixUrlsWithSpacesChunk: 'fixUrlsWithSpacesChunk',
+  scheduleHideAllMemberAddresses: 'scheduleHideAllMemberAddresses',
+  hideMemberAddressesChunk: 'hideMemberAddressesChunk',
   scheduleNormalizeMemberEmails: 'scheduleNormalizeMemberEmails',
   normalizeMemberEmailsChunk: 'normalizeMemberEmailsChunk',
   dailyPullExecutionCheck: 'dailyPullExecutionCheck',

--- a/backend/tasks/hide-addresses-methods.js
+++ b/backend/tasks/hide-addresses-methods.js
@@ -1,0 +1,159 @@
+const { taskManager } = require('psdev-task-manager');
+
+const { COLLECTIONS, ADDRESS_STATUS_TYPES } = require('../../public/consts');
+const { wixData } = require('../elevated-modules');
+const { bulkSaveMembers, getMembersByIds } = require('../members-data-methods');
+const { chunkArray, queryAllItems } = require('../utils');
+
+const { TASKS_NAMES } = require('./consts');
+
+const CHUNK_SIZE = 1000;
+
+const getMemberAddresses = member => (Array.isArray(member.addresses) ? member.addresses : []);
+
+/**
+ * Whether a member has at least one address that is not already hidden.
+ * @param {Object} member
+ * @returns {boolean}
+ */
+const hasVisibleAddress = member =>
+  getMemberAddresses(member).some(
+    address => address && address.addressStatus !== ADDRESS_STATUS_TYPES.DONT_SHOW
+  );
+
+/**
+ * Sets every address on a member to DONT_SHOW (other address fields are preserved).
+ * @param {Object} member
+ * @returns {Array} the member's addresses with addressStatus set to DONT_SHOW
+ */
+const hideMemberAddresses = member =>
+  getMemberAddresses(member).map(address => ({
+    ...address,
+    addressStatus: ADDRESS_STATUS_TYPES.DONT_SHOW,
+  }));
+
+/**
+ * Schedules tasks to hide ALL addresses for ALL members that have any address.
+ * Manually triggered (not cron-wired). Sets each address's addressStatus to DONT_SHOW.
+ */
+async function scheduleHideAllMemberAddresses() {
+  console.log('=== Scheduling Hide All Member Addresses Tasks ===');
+
+  try {
+    const membersQuery = await wixData
+      .query(COLLECTIONS.MEMBERS_DATA)
+      .isNotEmpty('addresses')
+      .limit(1000);
+    const members = await queryAllItems(membersQuery);
+    console.log(`Fetched ${members.length} members with addresses`);
+
+    // Only members that still have at least one visible address need updating.
+    const memberIds = [
+      ...new Set(
+        members
+          .filter(hasVisibleAddress)
+          .map(member => Number(member.memberId))
+          .filter(memberId => Number.isFinite(memberId) && memberId > 0)
+      ),
+    ];
+    console.log(`Members with at least one visible address: ${memberIds.length}`);
+
+    if (memberIds.length === 0) {
+      console.log('No members need their addresses hidden');
+      return {
+        success: true,
+        message: 'No members need their addresses hidden',
+        totalMembers: 0,
+        tasksScheduled: 0,
+      };
+    }
+
+    const chunks = chunkArray(memberIds, CHUNK_SIZE);
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      await taskManager().schedule({
+        name: TASKS_NAMES.hideMemberAddressesChunk,
+        data: {
+          memberIds: chunk,
+          chunkIndex: i,
+          totalChunks: chunks.length,
+        },
+        type: 'scheduled',
+      });
+      console.log(`Scheduled task ${i + 1}/${chunks.length} (${chunk.length} members)`);
+    }
+
+    const result = {
+      success: true,
+      message: `Scheduled ${chunks.length} tasks for ${memberIds.length} members`,
+      totalMembers: memberIds.length,
+      tasksScheduled: chunks.length,
+    };
+    console.log('=== Scheduling Complete ===');
+    console.log(JSON.stringify(result, null, 2));
+    return result;
+  } catch (error) {
+    console.error('Error scheduling hide-all-addresses:', error);
+    throw error;
+  }
+}
+
+/**
+ * Processes a chunk of members and sets every address to DONT_SHOW.
+ * @param {Object} data
+ * @param {Array<number|string>} data.memberIds
+ * @param {number} data.chunkIndex
+ * @param {number} data.totalChunks
+ */
+async function hideMemberAddressesChunk(data) {
+  const { memberIds, chunkIndex, totalChunks } = data;
+  console.log(
+    `Processing hide-addresses chunk ${chunkIndex + 1}/${totalChunks} (${memberIds.length} members)`
+  );
+
+  const result = { successful: 0, failed: 0, skipped: 0, errors: [], failedIds: [] };
+
+  try {
+    const members = await getMembersByIds(memberIds);
+    console.log(`Loaded ${members.length} members for this chunk`);
+
+    const membersToUpdate = [];
+    members.forEach(member => {
+      // Skip members that have no address or are already fully hidden.
+      if (!hasVisibleAddress(member)) {
+        result.skipped++;
+        return;
+      }
+      membersToUpdate.push({
+        ...member,
+        addresses: hideMemberAddresses(member),
+      });
+    });
+
+    if (membersToUpdate.length === 0) {
+      console.log('No members need updating in this batch');
+      return result;
+    }
+
+    try {
+      await bulkSaveMembers(membersToUpdate);
+      result.successful += membersToUpdate.length;
+      console.log(`✅ Successfully hid addresses for ${membersToUpdate.length} members`);
+    } catch (error) {
+      console.error('❌ Error bulk saving members:', error);
+      result.failed += membersToUpdate.length;
+      result.failedIds.push(...membersToUpdate.map(member => member.memberId));
+      result.errors.push({ error: error.message, memberCount: membersToUpdate.length });
+    }
+
+    return result;
+  } catch (error) {
+    console.error(`Error processing hide-addresses chunk ${chunkIndex}:`, error);
+    throw error;
+  }
+}
+
+module.exports = {
+  scheduleHideAllMemberAddresses,
+  hideMemberAddressesChunk,
+};

--- a/backend/tasks/tasks-configs.js
+++ b/backend/tasks/tasks-configs.js
@@ -15,6 +15,10 @@ const {
   normalizeMemberEmailsChunk,
 } = require('./email-normalize-methods');
 const {
+  scheduleHideAllMemberAddresses,
+  hideMemberAddressesChunk,
+} = require('./hide-addresses-methods');
+const {
   scheduleTaskForEmptyAboutYouMembers,
   convertAboutYouHtmlToRichContent,
   compileFiltersOptions,
@@ -204,6 +208,20 @@ const TASKS = {
     name: TASKS_NAMES.fixUrlsWithSpacesChunk,
     getIdentifier: task => task.data,
     process: fixUrlsWithSpacesChunk,
+    shouldSkipCheck: () => false,
+    estimatedDurationSec: 80,
+  },
+  [TASKS_NAMES.scheduleHideAllMemberAddresses]: {
+    name: TASKS_NAMES.scheduleHideAllMemberAddresses,
+    getIdentifier: () => 'SHOULD_NEVER_SKIP',
+    process: scheduleHideAllMemberAddresses,
+    shouldSkipCheck: () => false,
+    estimatedDurationSec: 80,
+  },
+  [TASKS_NAMES.hideMemberAddressesChunk]: {
+    name: TASKS_NAMES.hideMemberAddressesChunk,
+    getIdentifier: task => task.data,
+    process: hideMemberAddressesChunk,
     shouldSkipCheck: () => false,
     estimatedDurationSec: 80,
   },


### PR DESCRIPTION
## What
Adds a **manually-triggered** task-manager job that hides every address for every member by setting each address's `addressStatus` to `DONT_SHOW`.

## Why
On profiles, address visibility is driven by each address's `addressStatus`, **not** by `addressDisplayOption` — `findMainAddress` falls back to the first address whose `addressStatus !== DONT_SHOW`. So to hide all addresses across the directory, every address object must be set to `DONT_SHOW`.

## How
New file `backend/tasks/hide-addresses-methods.js`, mirroring the existing `fixPrimaryAddressForMembers` pattern:

- **`scheduleHideAllMemberAddresses`** — queries members with a non-empty `addresses` array, keeps only those that still have at least one visible address, chunks the memberIds (1000/chunk), and schedules per-chunk tasks.
- **`hideMemberAddressesChunk`** — loads each chunk via `getMembersByIds`, sets every address's `addressStatus` to `DONT_SHOW` (all other address fields preserved), and `bulkSaveMembers`. Skips members that are already fully hidden.
- Registered in `tasks/consts.js` + `tasks-configs.js`, and exposed at the package boundary as **`scheduleHideAllMemberAddressesTask`** (same as the other one-off maintenance schedulers).

## Notes
- **Destructive / one-off:** it does not touch `addressDisplayOption` (unnecessary — once every address is `DONT_SHOW`, `findMainAddress` returns empty). It is **not** cron-wired; trigger it manually like the other migration tasks.
- Idempotent: re-running skips members whose addresses are already all `DONT_SHOW`.
- No tests added, matching the convention of the existing maintenance tasks (`address-primary-methods`, `url-space-fix-methods`). Lint, cycle-check, Prettier clean; existing suite passes.

## To run (after publishing a new abmp-npm version)
Call `scheduleHideAllMemberAddressesTask()` from a site backend function (e.g. a temporary `jobs.js` export), then let the `runScheduledTasks` worker drain the chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)