### PR TITLE
Fix repeater delete race in Your Services + Testimonials (DOM-recycling)

### DIFF
--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -999,12 +999,8 @@ async function personalDetailsOnReady({
     const interestsData = await getInterestAll();
 
     _$w('#removeServiceButton').onClick(async event => {
-      // Capture the stable item id BEFORE awaiting the confirm lightbox.
-      // Reading the chip's text after the await is unsafe: the repeater
-      // recycles its DOM items on re-render, so after a rapid sequence of
-      // deletes event.context can resolve to a recycled node showing a
-      // different service, removing the wrong item (or none). Matching on
-      // the stable _id (as the gallery delete does) avoids that race.
+      // Capture the id before the await: the repeater recycles DOM items on
+      // re-render, so reading the chip text afterwards can target the wrong one.
       const itemId = event.context.itemId;
       const result = await wixWindow.openLightbox(LIGHTBOX_NAMES.DELETE_CONFIRM);
 
@@ -1090,9 +1086,7 @@ async function personalDetailsOnReady({
   }
 
   function renderServices() {
-    // Pass a fresh array copy so the Wix repeater detects the change and
-    // re-renders. Assigning the same array reference (mutated in place by
-    // add/delete) is treated as a no-op, leaving stale chips on screen.
+    // Fresh copy so the repeater detects the change (same reference is a no-op).
     setupRepeater('#servicesRepeater', [...selectedServices]);
   }
 

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -998,8 +998,21 @@ async function personalDetailsOnReady({
   async function setInterestData() {
     const interestsData = await getInterestAll();
 
-    _$w('#removeServiceButton').onClick(event => {
-      handleItemDelete(event, '#serviceNameText', selectedServices, 'label', renderServices);
+    _$w('#removeServiceButton').onClick(async event => {
+      // Capture the stable item id BEFORE awaiting the confirm lightbox.
+      // Reading the chip's text after the await is unsafe: the repeater
+      // recycles its DOM items on re-render, so after a rapid sequence of
+      // deletes event.context can resolve to a recycled node showing a
+      // different service, removing the wrong item (or none). Matching on
+      // the stable _id (as the gallery delete does) avoids that race.
+      const itemId = event.context.itemId;
+      const result = await wixWindow.openLightbox(LIGHTBOX_NAMES.DELETE_CONFIRM);
+
+      if (result && result.toDelete) {
+        selectedServices = selectedServices.filter(service => service._id !== itemId);
+        renderServices();
+        checkFormChanges(FORM_SECTION_HANDLER_MAP.BUSINESS_SERVICES);
+      }
     });
 
     if (Array.isArray(interestsData) && interestsData.length > 0) {

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -975,26 +975,6 @@ async function personalDetailsOnReady({
     });
   }
 
-  async function handleItemDelete(event, getTextSelector, arrayRef, matchField, renderFn) {
-    const result = await wixWindow.openLightbox(LIGHTBOX_NAMES.DELETE_CONFIRM);
-
-    if (result && result.toDelete) {
-      const $clickedItem = _$w.at(event.context);
-      const textToRemove = $clickedItem(getTextSelector).text;
-
-      arrayRef.splice(
-        0,
-        arrayRef.length,
-        ...arrayRef.filter(item =>
-          typeof item === 'string' ? item !== textToRemove : item[matchField] !== textToRemove
-        )
-      );
-
-      renderFn();
-      checkFormChanges(FORM_SECTION_HANDLER_MAP.BUSINESS_SERVICES);
-    }
-  }
-
   async function setInterestData() {
     const interestsData = await getInterestAll();
 
@@ -1349,14 +1329,24 @@ async function personalDetailsOnReady({
     const addTestimonialButton = _$w('#addTestimonialButton');
 
     addTestimonialButton.onClick(handleAddTestimonial);
-    _$w('#deleteTestimonialButton').onClick(event => {
-      handleItemDelete(
-        event,
-        '#testimonialText',
-        itemMemberObj.testimonial,
-        null,
-        renderTestimonials
-      );
+    _$w('#deleteTestimonialButton').onClick(async event => {
+      // Resolve the clicked item's index before the await: the repeater
+      // recycles DOM items on re-render, so reading the chip text afterwards
+      // can target the wrong one. Index 0 is the non-deletable add item.
+      const data = _$w('#testimonialRepeater').data || [];
+      const clickedIndex = data.findIndex(item => item._id === event.context.itemId);
+      const result = await wixWindow.openLightbox(LIGHTBOX_NAMES.DELETE_CONFIRM);
+
+      if (
+        result &&
+        result.toDelete &&
+        clickedIndex > 0 &&
+        Array.isArray(itemMemberObj.testimonial)
+      ) {
+        itemMemberObj.testimonial.splice(clickedIndex - 1, 1);
+        renderTestimonials();
+        checkFormChanges(FORM_SECTION_HANDLER_MAP.BUSINESS_SERVICES);
+      }
     });
 
     renderTestimonials();

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -979,8 +979,6 @@ async function personalDetailsOnReady({
     const interestsData = await getInterestAll();
 
     _$w('#removeServiceButton').onClick(async event => {
-      // Capture the id before the await: the repeater recycles DOM items on
-      // re-render, so reading the chip text afterwards can target the wrong one.
       const itemId = event.context.itemId;
       const result = await wixWindow.openLightbox(LIGHTBOX_NAMES.DELETE_CONFIRM);
 
@@ -1066,7 +1064,6 @@ async function personalDetailsOnReady({
   }
 
   function renderServices() {
-    // Fresh copy so the repeater detects the change (same reference is a no-op).
     setupRepeater('#servicesRepeater', [...selectedServices]);
   }
 
@@ -1330,9 +1327,6 @@ async function personalDetailsOnReady({
 
     addTestimonialButton.onClick(handleAddTestimonial);
     _$w('#deleteTestimonialButton').onClick(async event => {
-      // Resolve the clicked item's index before the await: the repeater
-      // recycles DOM items on re-render, so reading the chip text afterwards
-      // can target the wrong one. Index 0 is the non-deletable add item.
       const data = _$w('#testimonialRepeater').data || [];
       const clickedIndex = data.findIndex(item => item._id === event.context.itemId);
       const result = await wixWindow.openLightbox(LIGHTBOX_NAMES.DELETE_CONFIRM);

--- a/pages/personalDetails.js
+++ b/pages/personalDetails.js
@@ -1077,7 +1077,10 @@ async function personalDetailsOnReady({
   }
 
   function renderServices() {
-    setupRepeater('#servicesRepeater', selectedServices);
+    // Pass a fresh array copy so the Wix repeater detects the change and
+    // re-renders. Assigning the same array reference (mutated in place by
+    // add/delete) is treated as a no-op, leaving stale chips on screen.
+    setupRepeater('#servicesRepeater', [...selectedServices]);
   }
 
   function setupRepeater(repeaterId, data) {


### PR DESCRIPTION
## Problem

Users were unable to delete chips in the **Your Services** section. The confirm dialog opened and closed normally, but the clicked chip stayed on screen. The failure was timing-dependent: deleting slowly worked, but deleting **multiple times in quick succession** left the clicked chip behind.

## Root cause

The service delete handler identified which item to remove by reading the **displayed text** of the clicked repeater item (`#serviceNameText`) **after** awaiting the confirm lightbox:

```js
const result = await wixWindow.openLightbox(...);
const $clickedItem = _$w.at(event.context);
const textToRemove = $clickedItem('#serviceNameText').text; // read AFTER await
```

Wix repeaters **recycle their DOM items** on every re-render. During a rapid sequence of deletes, the previous delete's re-render hadn't settled, so by the time `textToRemove` was read, `event.context` resolved to a recycled node showing a *different* service — removing the wrong item, or none. Slow deletes worked because the repeater settled between clicks.

The Gallery delete never had this bug because it captures a stable `_id` **before** the await and matches on it.

## Fix

**Services**
- Match by stable `_id` captured **before** the await (mirrors the Gallery delete), removing the dependency on recycled DOM text and the post-await timing window.
- `renderServices()` hands the repeater a fresh array copy, which also protects the add path (`unshift` mutates in place).

**Testimonials**
- Was the last caller of the shared `handleItemDelete` helper, which had the same read-text-after-await flaw. The store is an array of strings with no `_id`, so the clicked item's **index is resolved from the repeater data before the await** and removed by index. This also fixes deleting the wrong entry when two testimonials share the same text.

**Cleanup**
- With both callers converted, `handleItemDelete` is dead code and was removed.

## Already robust (no change needed)

- **Phones** (`#removePhoneBtn`) and **Addresses** (`#addressItemRemoveBtn`) already resolve the clicked item by `_id` before the await, so they were never affected by this race.

## Testing

- `npm run lint` (madge circular-dependency check + ESLint) — pass
- Prettier format check — pass
- Manual: deleting services and testimonials rapidly now removes the correct item each time.
